### PR TITLE
Add SEC EDGAR backend for structured 10-K financial data

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Copy `server/.env.example` to `server/.env` and set your email before deploying.
 | `GET /api/sec/model-data?ticker=NFLX&years=5` | Latest 5 annual 10-K periods |
 | `GET /api/sec/profile?ticker=NFLX` | Case-study profile: industry, HQ, filings + financial snapshot |
 | `GET /api/sec/business?ticker=NFLX` | "Item 1 — Business" narrative extracted from the latest 10-K |
+| `GET /api/sec/income-statement?ticker=NFLX` | P&L recast into Companies Act 2013 Schedule III (Part II) |
 | `GET /api/sec/balance-sheet?ticker=NFLX` | Balance sheet recast into Companies Act 2013 Schedule III vertical format |
 | `GET /api/sec/ratios?ticker=NFLX` | Working-capital, liquidity, leverage & return ratios per year |
 | `GET /api/sec/wacc?ticker=NFLX` | Cost of capital (see WACC section below) |
@@ -144,6 +145,16 @@ snapshot (revenue, YoY growth, margins, ROE) — a quick case-study brief.
 ratio, working capital, **DSO / DPO / DIO and the cash-conversion cycle**,
 debt/equity, debt/assets, interest coverage, net margin, ROE and ROA — all
 computed from the normalized SEC figures.
+
+## Statements — Companies Act 2013, Schedule III
+
+`income-statement` recasts the P&L into **Schedule III, Part II**: Revenue from
+operations → Other income → **Total Income** → Expenses (cost of revenue, finance
+costs, other expenses) → **Profit Before Tax** → tax (current/deferred) → **Profit
+for the period** → EPS (basic/diluted). US-GAAP uses *functional* expense
+classification, so the reconciling **"Other expenses"** line absorbs operating
+costs (R&D, S&M, G&A) and embedded D&A, anchored so Total Income − Total
+Expenses = the reported Profit Before Tax.
 
 ## Balance sheet — Companies Act 2013, Schedule III
 

--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ non-current). Always treat the raw tag as the source of truth.
 cd server
 npm install
 cp .env.example .env   # set SEC_CONTACT_EMAIL
-npm start              # http://localhost:3000  (UI + API)
+npm start              # http://localhost:5050  (UI + API)
 npm test               # Jest suite (mocked SEC responses)
 ```
 
-Open `http://localhost:3000`, enter a ticker (e.g. **NFLX**) and fetch. Hover any
+Open `http://localhost:5050`, enter a ticker (e.g. **NFLX**) and fetch. Hover any
 value to see the exact US-GAAP tag behind it.
 
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Copy `server/.env.example` to `server/.env` and set your email before deploying.
 | `GET /api/sec/model-data?ticker=NFLX` | Normalized annual 10-K modelling data (curated ~50 line items) |
 | `GET /api/sec/model-data?ticker=NFLX&years=5` | Latest 5 annual 10-K periods |
 | `GET /api/sec/profile?ticker=NFLX` | Case-study profile: industry, HQ, filings + financial snapshot |
+| `GET /api/sec/business?ticker=NFLX` | "Item 1 — Business" narrative extracted from the latest 10-K |
 | `GET /api/sec/ratios?ticker=NFLX` | Working-capital, liquidity, leverage & return ratios per year |
 | `GET /api/sec/wacc?ticker=NFLX` | Cost of capital (see WACC section below) |
 | `GET /api/sec/segments?ticker=NFLX` | Revenue by segment / geography / product (parsed from the 10-K) |
@@ -149,13 +150,22 @@ a market-data provider; the rest is SEC/Treasury/assumption:
 | Tax rate (`Tc`) | SEC — income tax ÷ pre-tax income (clamped 0–50%) |
 | Book debt (`D`) | SEC — short-term + long-term debt |
 | Risk-free rate (`R_f`) | **US Treasury** 10-yr par yield (free, no key) |
-| Beta (`β`) | Market-data provider (default **Alpha Vantage** `OVERVIEW`) |
-| Market value of equity (`E`) | Market-data provider (market cap) |
+| Beta (`β`) | **Damodaran industry** asset beta, re-levered with this company's D/E + tax |
+| Market value of equity (`E`) | Market-data provider (market cap, e.g. Alpha Vantage) |
 | Equity risk premium (`ERP`) | Assumption (default 5.5%, overridable) |
 
-Get a **free** Alpha Vantage key at <https://www.alphavantage.co/support/#api-key>
-and set `ALPHAVANTAGE_API_KEY` in `server/.env`. Without a key, `/wacc` still
-works but returns beta/market-cap empty — supply them yourself.
+**Beta** is no longer a single-stock API regression. We map the company's SIC to
+an industry, take that industry's **unlevered (asset) beta** (à la Aswath
+Damodaran's free NYU Stern dataset), then re-lever it:
+`β_L = β_U · (1 + (1 − Tc)·D/E)`. The built-in table is an approximate seed —
+point `DAMODARAN_DATA_PATH` at the official downloaded data for production. The
+response's `beta` field shows the matched industry, unlevered/relevered values,
+D/E and vintage.
+
+**Market cap** still needs a price source: get a **free** Alpha Vantage key at
+<https://www.alphavantage.co/support/#api-key> and set `ALPHAVANTAGE_API_KEY`.
+Without it, the equity weight falls back to book equity for D/E — pass
+`?marketCap=` for the real market weight.
 
 Every input is overridable via query params so students can apply their own
 assumptions: `?beta=&rf=&erp=&marketCap=&costOfDebt=&taxRate=&totalDebt=`

--- a/README.md
+++ b/README.md
@@ -120,10 +120,14 @@ These breakdowns are **not** in the companyfacts JSON API — they only exist as
 4. groups revenue by axis (business segment, `srt:StatementGeographicalAxis`,
    `srt:ProductOrServiceAxis`, etc.) and member, per fiscal year.
 
-Limitations: only **single-axis, full-year** breakdowns are returned (product×
-geography intersection cells are skipped to avoid double-counting); it targets
-**inline-XBRL** filings (recent years) and reads the latest 10-K only. Members are
-shown by their raw XBRL QName (humanized) — always treat the source filing as
+Only **single-axis, full-year** breakdowns are tabled (product×geography
+intersection cells are skipped to avoid double-counting, but appear in
+`diagnostics`); it targets **inline-XBRL** filings (recent years). It **merges the
+latest N 10-Ks** (`?filings=N`, default 3, max 6) for more history than the ~3
+years a single filing tags — the most recently filed value wins per member/year.
+The response includes a `diagnostics` block listing every axis/member and axis
+combination found, to make missing breakdowns easy to debug. Members are shown by
+their raw XBRL QName (humanized) — always treat the source filing as
 authoritative.
 
 ## Company profile & ratios

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Copy `server/.env.example` to `server/.env` and set your email before deploying.
 | `GET /api/sec/profile?ticker=NFLX` | Case-study profile: industry, HQ, filings + financial snapshot |
 | `GET /api/sec/ratios?ticker=NFLX` | Working-capital, liquidity, leverage & return ratios per year |
 | `GET /api/sec/wacc?ticker=NFLX` | Cost of capital (see WACC section below) |
+| `GET /api/sec/segments?ticker=NFLX` | Revenue by segment / geography / product (parsed from the 10-K) |
 | `GET /api/sec/all-facts?ticker=NFLX` | **Every** annual us-gaap concept the company reported, as a time series |
 | `GET /api/sec/fields` | Metadata for the curated model (field keys, labels, statement, tags) |
 | `GET /api/sec/concept?ticker=NFLX&tag=Revenues` | One US-GAAP concept (raw) |
@@ -107,9 +108,22 @@ tagged in XBRL (often hundreds of concepts), use `all-facts`, which returns each
 concept by its raw US-GAAP tag with the same per-value audit trail. Companies use
 different tags, so all-facts uses the raw tag names rather than normalizing.
 
-**Note:** segment / product / geographic breakdowns are *not* available from the
-companyfacts JSON API (they live in the filing's dimensional XBRL); only
-consolidated/total values are exposed here.
+## Segment / geographic / product revenue
+
+These breakdowns are **not** in the companyfacts JSON API — they only exist as
+*dimensional* facts inside the filing's inline XBRL. `segments` therefore:
+
+1. finds the most recent 10-K from the submissions feed,
+2. downloads its primary inline-XBRL document,
+3. parses the contexts (axis/member dimensions) and revenue facts, and
+4. groups revenue by axis (business segment, `srt:StatementGeographicalAxis`,
+   `srt:ProductOrServiceAxis`, etc.) and member, per fiscal year.
+
+Limitations: only **single-axis, full-year** breakdowns are returned (product×
+geography intersection cells are skipped to avoid double-counting); it targets
+**inline-XBRL** filings (recent years) and reads the latest 10-K only. Members are
+shown by their raw XBRL QName (humanized) — always treat the source filing as
+authoritative.
 
 ## Company profile & ratios
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,13 @@ value to see the exact US-GAAP tag behind it.
 ## Limitations
 
 - Tag coverage varies by company and over time; missing values come back `null`
-  rather than guessed.
+  rather than guessed. A few values are **derived** and flagged as such: gross
+  profit (revenue − cost of revenue) and total liabilities (current +
+  non-current) when not tagged directly; treasury stock is sign-normalized to a
+  negative contra-equity value.
+- Per-share figures (EPS, weighted shares) use the **latest restated** filing so
+  the series is split-adjusted as far back as recent filings restate it; a
+  `warnings` entry flags a likely stock-split discontinuity beyond that point.
 - The fiscal year is derived from each fact's period-end date, which is a
   reasonable convention but may differ from a company's internal FY label.
 - The in-memory cache is per-process; use a shared cache (e.g. Redis) if you run

--- a/README.md
+++ b/README.md
@@ -162,10 +162,14 @@ point `DAMODARAN_DATA_PATH` at the official downloaded data for production. The
 response's `beta` field shows the matched industry, unlevered/relevered values,
 D/E and vintage.
 
-**Market cap** still needs a price source: get a **free** Alpha Vantage key at
-<https://www.alphavantage.co/support/#api-key> and set `ALPHAVANTAGE_API_KEY`.
-Without it, the equity weight falls back to book equity for D/E — pass
-`?marketCap=` for the real market weight.
+**Market cap** needs a price. If `ALPHAVANTAGE_API_KEY` is set it comes from
+there; otherwise it's derived **free, no key** as latest Stooq close × SEC shares
+outstanding. Beta is then re-levered with **market** D/E (book equity would
+inflate it). Override anytime with `?marketCap=`.
+
+The Cash Flow statement is presented in the three **AS 3 / IAS 7 indirect-method
+activities** (Operating, Investing, Financing) with each net-cash subtotal, plus
+a reconciliation (FX + net change in cash).
 
 Every input is overridable via query params so students can apply their own
 assumptions: `?beta=&rf=&erp=&marketCap=&costOfDebt=&taxRate=&totalDebt=`

--- a/README.md
+++ b/README.md
@@ -76,13 +76,37 @@ Copy `server/.env.example` to `server/.env` and set your email before deploying.
 | --- | --- |
 | `GET /api/sec/company?ticker=NFLX` | CIK, company name, tickers, exchange |
 | `GET /api/sec/companyfacts?ticker=NFLX` | Wrapped raw SEC companyfacts JSON |
-| `GET /api/sec/model-data?ticker=NFLX` | Normalized annual 10-K modelling data |
+| `GET /api/sec/model-data?ticker=NFLX` | Normalized annual 10-K modelling data (curated ~50 line items) |
 | `GET /api/sec/model-data?ticker=NFLX&years=5` | Latest 5 annual 10-K periods |
+| `GET /api/sec/all-facts?ticker=NFLX` | **Every** annual us-gaap concept the company reported, as a time series |
+| `GET /api/sec/fields` | Metadata for the curated model (field keys, labels, statement, tags) |
 | `GET /api/sec/concept?ticker=NFLX&tag=Revenues` | One US-GAAP concept (raw) |
 
-`model-data` returns one normalized object per fiscal year (revenue, cost of
-revenue, gross profit, operating income, net income, total/current assets, cash,
-total liabilities, equity, operating cash flow, capex, diluted EPS and shares).
+`model-data` returns one normalized object per fiscal year covering a curated
+**full three-statement** line-item set (~50 fields):
+
+- **Income statement** — revenue, cost of revenue, gross profit, R&D, selling &
+  marketing, G&A, SG&A, total opex, operating income, interest expense/income,
+  other non-operating income, pre-tax income, income tax, net income.
+- **Per share** — basic & diluted EPS, basic & diluted weighted shares,
+  dividends per share.
+- **Balance sheet** — cash, short-term investments, receivables, inventory,
+  other current assets, total current assets, PP&E, goodwill, intangibles, total
+  assets, payables, short-term/long-term debt, deferred revenue, current
+  liabilities, total liabilities, common stock, APIC, retained earnings, treasury
+  stock, AOCI, stockholders' equity.
+- **Cash flow** — D&A, stock-based comp, operating cash flow, capex,
+  acquisitions, investing cash flow, debt issued/repaid, buybacks, dividends
+  paid, financing cash flow.
+
+The curated set is intentionally not exhaustive. For **everything** a company
+tagged in XBRL (often hundreds of concepts), use `all-facts`, which returns each
+concept by its raw US-GAAP tag with the same per-value audit trail. Companies use
+different tags, so all-facts uses the raw tag names rather than normalizing.
+
+**Note:** segment / product / geographic breakdowns are *not* available from the
+companyfacts JSON API (they live in the filing's dimensional XBRL); only
+consolidated/total values are exposed here.
 
 ## Auditability
 

--- a/README.md
+++ b/README.md
@@ -124,8 +124,11 @@ These breakdowns are **not** in the companyfacts JSON API — they only exist as
 Only **single-axis, full-year** breakdowns are tabled (product×geography
 intersection cells are skipped to avoid double-counting, but appear in
 `diagnostics`); it targets **inline-XBRL** filings (recent years). It **merges the
-latest N 10-Ks** (`?filings=N`, default 3, max 6) for more history than the ~3
-years a single filing tags — the most recently filed value wins per member/year.
+latest N 10-Ks** for more history than the ~3 years a single filing tags — the
+most recently filed value wins per member/year. Request a span with
+`?years=10` (translated to the filings needed) or set filings directly with
+`?filings=N` (max 10 ≈ 12 years). In the UI the Periods selector drives this, so
+"Last 10" pulls ~8 filings.
 The response includes a `diagnostics` block listing every axis/member and axis
 combination found, to make missing breakdowns easy to debug. Members are shown by
 their raw XBRL QName (humanized) — always treat the source filing as

--- a/README.md
+++ b/README.md
@@ -11,3 +11,105 @@ I'm the GitHub Learning Lab bot and I'm here to help guide you in your journey t
 I'll meet you over there, can't wait to get started!
 
 This course is using the :sparkles: open source project [reveal.js](https://github.com/hakimel/reveal.js/). In some cases we’ve made changes to the history so it would behave during class, so head to the original project repo to learn more about the cool people behind this project.
+
+---
+
+# SEC EDGAR Integration (`server/`)
+
+A small Node.js + Express backend that fetches structured **10-K** financial
+statement data directly from the official **SEC EDGAR XBRL JSON APIs**, so
+students can build financial models without extracting numbers from PDFs.
+
+It lives in [`server/`](server/) and runs independently of the Jekyll slideshow
+above (GitHub Pages can only host static files, so the API must run locally or
+on a separate host).
+
+## Why XBRL JSON instead of PDF extraction
+
+Public companies file their financials as machine-readable **XBRL**, and the SEC
+exposes it as clean JSON. Parsing that is accurate and reproducible, whereas
+scraping numbers out of PDF annual reports is brittle and error-prone. This
+integration deliberately uses **only** the free, no-key, no-PDF JSON APIs.
+
+## SEC endpoints used
+
+| Purpose | Endpoint |
+| --- | --- |
+| Ticker → CIK mapping | `https://www.sec.gov/files/company_tickers.json` |
+| Company submissions / metadata | `https://data.sec.gov/submissions/CIK##########.json` |
+| Company XBRL facts (all tags) | `https://data.sec.gov/api/xbrl/companyfacts/CIK##########.json` |
+| Single concept (one tag) | `https://data.sec.gov/api/xbrl/companyconcept/CIK##########/us-gaap/<Tag>.json` |
+
+CIKs are zero-padded to 10 digits, e.g. `1065280` → `CIK0001065280`.
+
+## No API key — but a required User-Agent
+
+The SEC APIs need **no API key and no paid plan**. They do require a descriptive
+`User-Agent` identifying your app and a contact email. The contact email is read
+from an environment variable so you can replace it:
+
+```
+SEC_CONTACT_EMAIL=you@example.com
+```
+
+The backend sends:
+
+```
+User-Agent: FinancialModellingEducationApp you@example.com
+Accept-Encoding: gzip, deflate
+```
+
+Copy `server/.env.example` to `server/.env` and set your email before deploying.
+
+## Rate limits, retries, caching
+
+- **Max 10 requests/second** — the client spaces request starts to stay at or
+  below SEC's fair-access ceiling (configurable via `SEC_MAX_RPS`).
+- **Retry/backoff** — `429` and `5xx` responses (and transient network errors)
+  are retried with exponential backoff, honoring `Retry-After`.
+- **Caching** — successful responses are cached in-memory (default 24h) so
+  repeated student requests for the same ticker don't re-hit SEC servers.
+
+## API routes
+
+| Route | Description |
+| --- | --- |
+| `GET /api/sec/company?ticker=NFLX` | CIK, company name, tickers, exchange |
+| `GET /api/sec/companyfacts?ticker=NFLX` | Wrapped raw SEC companyfacts JSON |
+| `GET /api/sec/model-data?ticker=NFLX` | Normalized annual 10-K modelling data |
+| `GET /api/sec/model-data?ticker=NFLX&years=5` | Latest 5 annual 10-K periods |
+| `GET /api/sec/concept?ticker=NFLX&tag=Revenues` | One US-GAAP concept (raw) |
+
+`model-data` returns one normalized object per fiscal year (revenue, cost of
+revenue, gross profit, operating income, net income, total/current assets, cash,
+total liabilities, equity, operating cash flow, capex, diluted EPS and shares).
+
+## Auditability
+
+Different companies tag the same concept with different US-GAAP tags, so values
+**must remain auditable**. For every normalized value, `rawTagsUsed` records the
+original SEC tag, unit, fiscal year, accession number, filed date and form type
+(and flags derived values, such as total liabilities computed from current +
+non-current). Always treat the raw tag as the source of truth.
+
+## Running it
+
+```bash
+cd server
+npm install
+cp .env.example .env   # set SEC_CONTACT_EMAIL
+npm start              # http://localhost:3000  (UI + API)
+npm test               # Jest suite (mocked SEC responses)
+```
+
+Open `http://localhost:3000`, enter a ticker (e.g. **NFLX**) and fetch. Hover any
+value to see the exact US-GAAP tag behind it.
+
+## Limitations
+
+- Tag coverage varies by company and over time; missing values come back `null`
+  rather than guessed.
+- The fiscal year is derived from each fact's period-end date, which is a
+  reasonable convention but may differ from a company's internal FY label.
+- The in-memory cache is per-process; use a shared cache (e.g. Redis) if you run
+  multiple instances.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Copy `server/.env.example` to `server/.env` and set your email before deploying.
 | `GET /api/sec/model-data?ticker=NFLX&years=5` | Latest 5 annual 10-K periods |
 | `GET /api/sec/profile?ticker=NFLX` | Case-study profile: industry, HQ, filings + financial snapshot |
 | `GET /api/sec/business?ticker=NFLX` | "Item 1 — Business" narrative extracted from the latest 10-K |
+| `GET /api/sec/balance-sheet?ticker=NFLX` | Balance sheet recast into Companies Act 2013 Schedule III vertical format |
 | `GET /api/sec/ratios?ticker=NFLX` | Working-capital, liquidity, leverage & return ratios per year |
 | `GET /api/sec/wacc?ticker=NFLX` | Cost of capital (see WACC section below) |
 | `GET /api/sec/segments?ticker=NFLX` | Revenue by segment / geography / product (parsed from the 10-K) |
@@ -140,6 +141,21 @@ snapshot (revenue, YoY growth, margins, ROE) — a quick case-study brief.
 ratio, working capital, **DSO / DPO / DIO and the cash-conversion cycle**,
 debt/equity, debt/assets, interest coverage, net margin, ROE and ROA — all
 computed from the normalized SEC figures.
+
+## Balance sheet — Companies Act 2013, Schedule III
+
+`balance-sheet` recasts the US-GAAP figures into the **vertical Schedule III
+(Division I)** format: *I. Equity and Liabilities* (Shareholders' Funds →
+Non-Current Liabilities → Current Liabilities) then *II. Assets* (Non-Current →
+Current), with `TOTAL EQUITY AND LIABILITIES = TOTAL ASSETS`.
+
+Reconciliation logic: the SEC-reported control totals (Total/Current Assets,
+Total/Current Liabilities, Equity) are authoritative. Mapped US-GAAP items fill
+the Schedule III buckets, and a balancing **"Other …"** line in each group
+absorbs whatever isn't directly mapped (e.g. a streaming company's content
+liabilities). This guarantees every subtotal and the grand total tie out — the
+response includes a `balances`/`difference` check. The UI shows this in place of
+the flat balance-sheet table, with a ✓ balance check per year.
 
 ## WACC (cost of capital)
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ Copy `server/.env.example` to `server/.env` and set your email before deploying.
 | `GET /api/sec/companyfacts?ticker=NFLX` | Wrapped raw SEC companyfacts JSON |
 | `GET /api/sec/model-data?ticker=NFLX` | Normalized annual 10-K modelling data (curated ~50 line items) |
 | `GET /api/sec/model-data?ticker=NFLX&years=5` | Latest 5 annual 10-K periods |
+| `GET /api/sec/profile?ticker=NFLX` | Case-study profile: industry, HQ, filings + financial snapshot |
+| `GET /api/sec/ratios?ticker=NFLX` | Working-capital, liquidity, leverage & return ratios per year |
+| `GET /api/sec/wacc?ticker=NFLX` | Cost of capital (see WACC section below) |
 | `GET /api/sec/all-facts?ticker=NFLX` | **Every** annual us-gaap concept the company reported, as a time series |
 | `GET /api/sec/fields` | Metadata for the curated model (field keys, labels, statement, tags) |
 | `GET /api/sec/concept?ticker=NFLX&tag=Revenues` | One US-GAAP concept (raw) |
@@ -107,6 +110,43 @@ different tags, so all-facts uses the raw tag names rather than normalizing.
 **Note:** segment / product / geographic breakdowns are *not* available from the
 companyfacts JSON API (they live in the filing's dimensional XBRL); only
 consolidated/total values are exposed here.
+
+## Company profile & ratios
+
+`profile` combines SEC submissions metadata (industry/SIC, exchange, HQ, state of
+incorporation, fiscal year-end, recent 10-K filings) with a computed financial
+snapshot (revenue, YoY growth, margins, ROE) — a quick case-study brief.
+
+`ratios` returns per-year working-capital and analysis ratios: current/quick
+ratio, working capital, **DSO / DPO / DIO and the cash-conversion cycle**,
+debt/equity, debt/assets, interest coverage, net margin, ROE and ROA — all
+computed from the normalized SEC figures.
+
+## WACC (cost of capital)
+
+`WACC = (E/V)·Rₑ + (D/V)·R_d·(1−Tc)`, with `Rₑ = R_f + β·ERP`.
+
+SEC data does **not** include beta or market value of equity, so those come from
+a market-data provider; the rest is SEC/Treasury/assumption:
+
+| Input | Source |
+| --- | --- |
+| Cost of debt (`R_d`) | SEC — interest expense ÷ total debt |
+| Tax rate (`Tc`) | SEC — income tax ÷ pre-tax income (clamped 0–50%) |
+| Book debt (`D`) | SEC — short-term + long-term debt |
+| Risk-free rate (`R_f`) | **US Treasury** 10-yr par yield (free, no key) |
+| Beta (`β`) | Market-data provider (default **Alpha Vantage** `OVERVIEW`) |
+| Market value of equity (`E`) | Market-data provider (market cap) |
+| Equity risk premium (`ERP`) | Assumption (default 5.5%, overridable) |
+
+Get a **free** Alpha Vantage key at <https://www.alphavantage.co/support/#api-key>
+and set `ALPHAVANTAGE_API_KEY` in `server/.env`. Without a key, `/wacc` still
+works but returns beta/market-cap empty — supply them yourself.
+
+Every input is overridable via query params so students can apply their own
+assumptions: `?beta=&rf=&erp=&marketCap=&costOfDebt=&taxRate=&totalDebt=`
+(rates as decimals, e.g. `rf=0.043`). The UI exposes the same as editable fields
+with a live-recomputed breakdown.
 
 ## Auditability
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -19,3 +19,7 @@ SEC_CONTACT_EMAIL=gordeswapnil@gmail.com
 # Risk-free rate is pulled free (no key) from the US Treasury; these are fallbacks:
 # RISK_FREE_RATE=0.043
 # EQUITY_RISK_PREMIUM=0.055
+# Beta uses Damodaran INDUSTRY betas (no key). To use the official current data,
+# download the US "betas by industry" table, save as JSON ({ "Industry": unleveredBeta }),
+# and point this at it; otherwise an approximate built-in seed table is used.
+# DAMODARAN_DATA_PATH=/path/to/damodaran-betas.json

--- a/server/.env.example
+++ b/server/.env.example
@@ -4,7 +4,7 @@ SEC_CONTACT_EMAIL=gordeswapnil@gmail.com
 
 # Optional overrides (sensible defaults are baked in):
 # SEC_APP_NAME=FinancialModellingEducationApp
-# PORT=3000
+# PORT=5050
 # SEC_CACHE_TTL_MS=86400000
 # SEC_MAX_RPS=10
 # SEC_MAX_RETRIES=4

--- a/server/.env.example
+++ b/server/.env.example
@@ -9,3 +9,13 @@ SEC_CONTACT_EMAIL=gordeswapnil@gmail.com
 # SEC_MAX_RPS=10
 # SEC_MAX_RETRIES=4
 # SEC_BASE_BACKOFF_MS=500
+
+# ---- WACC / market data (only needed for the /wacc endpoint) ----
+# Beta and market cap are NOT in SEC data. Get a free Alpha Vantage key at
+# https://www.alphavantage.co/support/#api-key and set it here. Without a key,
+# /wacc still works but returns beta/market-cap empty (pass them as query params).
+# ALPHAVANTAGE_API_KEY=
+# MARKET_DATA_PROVIDER=alphavantage
+# Risk-free rate is pulled free (no key) from the US Treasury; these are fallbacks:
+# RISK_FREE_RATE=0.043
+# EQUITY_RISK_PREMIUM=0.055

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,11 @@
+# SEC requires a descriptive User-Agent that includes a contact address.
+# Replace this with your own email before deploying.
+SEC_CONTACT_EMAIL=gordeswapnil@gmail.com
+
+# Optional overrides (sensible defaults are baked in):
+# SEC_APP_NAME=FinancialModellingEducationApp
+# PORT=3000
+# SEC_CACHE_TTL_MS=86400000
+# SEC_MAX_RPS=10
+# SEC_MAX_RETRIES=4
+# SEC_BASE_BACKOFF_MS=500

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.env
+coverage/
+npm-debug.log*

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "express": "^4.19.2"
+        "express": "^4.19.2",
+        "fast-xml-parser": "^5.8.0"
       },
       "devDependencies": {
         "jest": "^29.7.0",
@@ -946,6 +947,18 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
@@ -2110,6 +2123,44 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -3764,6 +3815,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -4354,6 +4420,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/superagent": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
@@ -4692,6 +4770,21 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/y18n": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,0 +1,4757 @@
+{
+  "name": "sec-edgar-backend",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sec-edgar-backend",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "express": "^4.19.2"
+      },
+      "devDependencies": {
+        "jest": "^29.7.0",
+        "supertest": "^6.3.4"
+      },
+      "optionalDependencies": {
+        "dotenv": "^16.4.5"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/core/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+      "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/graceful-fs": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+      "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.32",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
+      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.361",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.361.tgz",
+      "integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.5.tgz",
+      "integrity": "sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
+      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
+      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "deprecated": "Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.1.2",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=6.4.0 <13 || >=14"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/superagent/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.4.tgz",
+      "integrity": "sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==",
+      "deprecated": "Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^8.1.2"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "sec-edgar-backend",
+  "version": "1.0.0",
+  "description": "Backend integration with the official SEC EDGAR XBRL JSON APIs for a financial modelling education app.",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "dev": "node src/server.js",
+    "test": "jest"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "express": "^4.19.2"
+  },
+  "optionalDependencies": {
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4"
+  },
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "fast-xml-parser": "^5.8.0"
   },
   "optionalDependencies": {
     "dotenv": "^16.4.5"

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -1022,10 +1022,15 @@
         }
         const btn = document.getElementById('segBtn');
         btn.disabled = true;
+        const years = document.getElementById('years').value;
+        const params = new URLSearchParams({ ticker: currentTicker });
+        // Each 10-K tags ~3 years, so more years => merge more filings.
+        if (years) params.set('years', years);
+        else params.set('filings', '10');
         document.getElementById('segNote').textContent =
-          'Fetching and parsing the latest 10-K inline XBRL (this can take a few seconds)…';
+          `Fetching and parsing ${years ? '~' + Math.max(Math.round(Number(years) - 2), 1) : 'up to 10'} 10-K filing(s) — this can take several seconds…`;
         try {
-          const res = await fetch(apiBase() + '/api/sec/segments?ticker=' + encodeURIComponent(currentTicker));
+          const res = await fetch(apiBase() + '/api/sec/segments?' + params.toString());
           const data = await res.json();
           if (!res.ok) throw new Error(data.error || ('Request failed (' + res.status + ')'));
           renderSegments(data);

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -444,6 +444,7 @@
           setStatus('Loaded ' + ticker + ' — live SEC data.');
           render(data);
           fetchProfile(base, ticker, data.periods);
+          fetchWaccInputs();
         } catch (err) {
           setStatus('Error: ' + err.message + ' — is the backend running at ' + base + '?', 'error');
         } finally {
@@ -458,6 +459,7 @@
         const d = buildDemo();
         render(d);
         renderProfile(DEMO_PROFILE, d.periods);
+        renderBusiness(DEMO_BUSINESS);
         renderSegments(DEMO_SEGMENTS);
       }
 
@@ -546,17 +548,26 @@
       const pctStr = (v, dp = 1) => (v == null ? '—' : (v * 100).toFixed(dp) + '%');
       const kpi = (label, num, cls = '') => `<div class="kpi ${cls}"><div class="label">${esc(label)}</div><div class="num ${cls}">${num}</div></div>`;
 
+      const xRatio = (v) => (v == null ? '—' : v.toFixed(2) + '×');
       function snapshotClient(periods) {
         if (!periods || !periods.length) return null;
         const L = periods[0], P = periods[1] || null;
         const div = (a, b) => (a == null || b == null || b === 0 ? null : a / b);
+        const totalDebt = (L.shortTermDebt || 0) + (L.longTermDebt || 0) || null;
         return {
           fiscalYear: L.fiscalYear, revenue: L.revenue,
           revenueGrowth: P ? div((L.revenue || 0) - (P.revenue || 0), P.revenue) : null,
           grossMargin: div(L.grossProfit, L.revenue), operatingMargin: div(L.operatingIncome, L.revenue),
-          netMargin: div(L.netIncome, L.revenue), returnOnEquity: div(L.netIncome, L.stockholdersEquity),
+          netMargin: div(L.netIncome, L.revenue),
+          returnOnEquity: div(L.netIncome, L.stockholdersEquity), returnOnAssets: div(L.netIncome, L.totalAssets),
+          currentRatio: div(L.currentAssets, L.currentLiabilities), debtToEquity: div(totalDebt, L.stockholdersEquity),
+          freeCashFlow: L.operatingCashFlow != null && L.capitalExpenditure != null ? L.operatingCashFlow - L.capitalExpenditure : null,
         };
       }
+      const DEMO_BUSINESS = {
+        sourceDocument: '(sample data)',
+        business: { excerpt: 'Item 1. Business — Netflix is one of the world\'s leading entertainment services, offering TV series, films and games across a wide variety of genres and languages to paying members in over 190 countries. (Sample text for layout preview; load live data for the real 10-K business description.)', truncated: false },
+      };
       function renderProfile(meta, periods) {
         const s = snapshotClient(periods);
         const f = (l, v) => (v ? `<span class="f">${esc(l)}: <b>${esc(v)}</b></span>` : '');
@@ -577,12 +588,34 @@
             kpi('Operating margin', pctStr(s.operatingMargin)) +
             kpi('Net margin', pctStr(s.netMargin)) +
             kpi('Return on equity', pctStr(s.returnOnEquity)) +
+            kpi('Return on assets', pctStr(s.returnOnAssets)) +
+            kpi('Current ratio', xRatio(s.currentRatio)) +
+            kpi('Debt / Equity', xRatio(s.debtToEquity)) +
+            kpi('Free cash flow', moneyStr(s.freeCashFlow)) +
             `</div>`;
         }
         document.getElementById('profile').innerHTML =
           `<div class="card"><h3>Company profile</h3>` +
           `<div class="facts">${facts}</div>` +
-          (meta.narrative ? `<p class="narrative">${esc(meta.narrative)}</p>` : '') + snap + `</div>`;
+          (meta.narrative ? `<p class="narrative">${esc(meta.narrative)}</p>` : '') + snap +
+          `<div id="bizBox"></div></div>`;
+      }
+      function renderBusiness(data) {
+        const box = document.getElementById('bizBox');
+        if (!box) return;
+        if (!data || !data.business || !data.business.excerpt) { box.innerHTML = ''; return; }
+        const src = data.sourceDocument && data.sourceDocument.startsWith('http')
+          ? ` · <a href="${esc(data.sourceDocument)}" target="_blank" rel="noopener" style="color:var(--accent)">source 10-K</a>` : '';
+        box.innerHTML = `<details style="margin-top:0.7rem"><summary style="cursor:pointer;color:var(--accent);font-weight:600">Business overview (10-K, Item 1)${src}</summary>` +
+          `<p class="narrative" style="white-space:pre-wrap">${esc(data.business.excerpt)}</p></details>`;
+      }
+      async function fetchBusiness(base, ticker) {
+        try {
+          const res = await fetch(base + '/api/sec/business?ticker=' + encodeURIComponent(ticker));
+          const data = await res.json();
+          if (!res.ok) return;
+          renderBusiness(data);
+        } catch (_) { /* leave empty */ }
       }
       async function fetchProfile(base, ticker, periods) {
         try {
@@ -593,6 +626,7 @@
             industry: data.industry, exchanges: data.exchanges, stateOfIncorporation: data.stateOfIncorporation,
             fiscalYearEnd: data.fiscalYearEnd, headquarters: data.headquarters, narrative: data.narrative,
           }, periods);
+          fetchBusiness(base, ticker);
         } catch (_) {
           document.getElementById('profile').innerHTML = '';
         }
@@ -696,7 +730,7 @@
             waccField('wRf', 'Risk-free %', waccState.rf, '4.3') +
             waccField('wErp', 'Equity risk premium %', waccState.erp, '5.5') +
             waccField('wMc', 'Market cap ($)', waccState.marketCap, 'e.g. 350000000000') +
-            `<div class="field"><label>&nbsp;</label><button id="waccFetch" class="ghost" type="button">Fetch β & market cap</button></div>` +
+            `<div class="field"><label>&nbsp;</label><button id="waccFetch" class="ghost" type="button">Fetch industry β, market cap & risk-free</button></div>` +
           `</div><div id="waccOut" class="wacc-out"></div><p class="muted" id="waccNote"></p></div></section>`;
         ['wBeta', 'wRf', 'wErp', 'wMc'].forEach((id) =>
           document.getElementById(id).addEventListener('input', recomputeWacc));
@@ -744,14 +778,22 @@
           const res = await fetch(apiBase() + '/api/sec/wacc?ticker=' + encodeURIComponent(currentTicker));
           const data = await res.json();
           if (!res.ok) throw new Error(data.error || ('Request failed (' + res.status + ')'));
-          if (data.inputs.beta != null) document.getElementById('wBeta').value = data.inputs.beta;
+          if (data.inputs.beta != null) document.getElementById('wBeta').value = Number(data.inputs.beta).toFixed(2);
           if (data.inputs.marketValueOfEquity != null) document.getElementById('wMc').value = data.inputs.marketValueOfEquity;
           if (data.inputs.riskFreeRate != null) document.getElementById('wRf').value = (data.inputs.riskFreeRate * 100).toFixed(2);
           recomputeWacc();
-          if (!data.meta.marketDataConfigured) {
-            document.getElementById('waccNote').textContent =
-              'Backend has no market-data API key (ALPHAVANTAGE_API_KEY), so β and market cap came back empty — enter them manually or set a key and retry.';
+          const b = data.beta || {};
+          let note = '';
+          if (b.industry) {
+            const rel = b.releveredBeta != null ? b.releveredBeta.toFixed(2) : '—';
+            const de = b.deRatioUsed != null ? b.deRatioUsed.toFixed(2) : 'n/a';
+            const tax = b.taxRateUsed != null ? (b.taxRateUsed * 100).toFixed(0) + '%' : 'n/a';
+            note += `β = ${b.industry} industry asset β ${b.unleveredBeta} re-levered to ${rel} (D/E ${de} ${b.deRatioBasis || ''}, tax ${tax}; ${b.vintage}). `;
           }
+          note += data.meta.marketDataConfigured
+            ? `Market cap from ${data.meta.marketDataSource}.`
+            : 'Market cap unavailable (no ALPHAVANTAGE_API_KEY) — enter it manually for the equity weight.';
+          document.getElementById('waccNote').textContent = note;
         } catch (err) {
           document.getElementById('waccNote').textContent = 'Fetch error: ' + err.message;
         } finally {

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -75,6 +75,11 @@
       tr.bs-grand td { font-weight: 800; border-top: 2px solid var(--accent); border-bottom: 2px solid var(--accent); color: var(--accent); }
       tr.bs-grand td.metric { background: #16243f; }
       tr.bs-check td { font-size: 0.78rem; color: var(--muted); }
+      tr.drill { cursor: pointer; }
+      tr.drill td.metric .caret { color: var(--accent); display: inline-block; width: 0.9rem; }
+      tr.drill:hover td.metric { color: var(--accent); }
+      tr.bs-detail td { color: var(--muted); font-size: 0.8rem; }
+      tr.bs-detail td.metric { font-weight: 400; }
       td .tag, td.tagcol .tag { display: block; font-size: 0.68rem; color: var(--muted); margin-top: 0.05rem; }
       .na { color: #56688a; }
       .allctrl { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; margin-bottom: 0.6rem; }
@@ -464,31 +469,60 @@
         const netIncome = n(v.netIncome);
         const otherItems = netIncome != null && pat != null ? netIncome - pat : null;
 
-        const L = (label, kind, level, value, unit) => ({ label, kind, level, value, unit: unit || 'USD' });
+        const L = (key, label, kind, level, value, unit) => ({ key, label, kind, level, value, unit: unit || 'USD' });
         const lines = [
-          L('I. Revenue from operations', 'item', 1, revenue),
-          L('II. Other income', 'item', 1, otherIncome),
-          L('III. Total Income (I + II)', 'subtotal', 0, totalIncome),
-          L('IV. Expenses', 'header', 1, null),
-          L('Cost of revenue / materials & services', 'item', 2, cor),
-          L('Finance costs', 'item', 2, fc),
-          L('Other expenses (operating & unmapped)', 'item', 2, otherExp),
-          L('Total Expenses', 'subtotal', 1, totalExpenses),
-          L('V. Profit Before Tax (III − IV)', 'subtotal', 0, pbt),
-          L('VI. Tax expense', 'header', 1, null),
-          L('(1) Current tax', 'item', 2, currentTax),
-          L('(2) Deferred tax', 'item', 2, deferredTax),
-          L('Total tax expense', 'subtotal', 1, totalTax),
-          L('VII. Profit After Tax (V − VI)', 'subtotal', 0, pat),
-          L('VIII. Other items (NCI, discontinued ops)', 'item', 1, otherItems),
-          L('IX. Profit for the period', 'grandtotal', 0, netIncome),
-          L('X. Earnings per equity share', 'header', 1, null),
-          L('(1) Basic', 'item', 2, n(v.epsBasic), 'USD/shares'),
-          L('(2) Diluted', 'item', 2, n(v.dilutedEPS), 'USD/shares'),
+          L('rev', 'I. Revenue from operations', 'item', 1, revenue),
+          L('oi', 'II. Other income', 'item', 1, otherIncome),
+          L('ti', 'III. Total Income (I + II)', 'subtotal', 0, totalIncome),
+          L('exp', 'IV. Expenses', 'header', 1, null),
+          L('cor', 'Cost of revenue / materials & services', 'item', 2, cor),
+          L('fc', 'Finance costs', 'item', 2, fc),
+          L('oe', 'Other expenses (operating & unmapped)', 'item', 2, otherExp),
+          L('te', 'Total Expenses', 'subtotal', 1, totalExpenses),
+          L('pbt', 'V. Profit Before Tax (III − IV)', 'subtotal', 0, pbt),
+          L('tax', 'VI. Tax expense', 'header', 1, null),
+          L('ct', '(1) Current tax', 'item', 2, currentTax),
+          L('dt', '(2) Deferred tax', 'item', 2, deferredTax),
+          L('tt', 'Total tax expense', 'subtotal', 1, totalTax),
+          L('pat', 'VII. Profit After Tax (V − VI)', 'subtotal', 0, pat),
+          L('oth', 'VIII. Other items (NCI, discontinued ops)', 'item', 1, otherItems),
+          L('pfp', 'IX. Profit for the period', 'grandtotal', 0, netIncome),
+          L('eps', 'X. Earnings per equity share', 'header', 1, null),
+          L('epsb', '(1) Basic', 'item', 2, n(v.epsBasic), 'USD/shares'),
+          L('epsd', '(2) Diluted', 'item', 2, n(v.dilutedEPS), 'USD/shares'),
         ];
         return { lines };
       }
-      function renderScheduleTable(title, schedules, periods, yearHeads, legend) {
+      // Drill-down detail for aggregated P&L lines (built from the loaded period
+      // fields; a balancing "Other / unallocated" row makes detail tie to the
+      // heading). field = model-data key on each period.
+      const PL_DETAIL = {
+        oi: { items: [['Interest / investment income', 'interestIncome'], ['Other non-operating income', 'otherIncomeExpense']] },
+        oe: {
+          items: [['Research & development', 'researchAndDevelopment'], ['Selling & marketing', 'sellingAndMarketing'],
+            ['General & administrative', 'generalAndAdministrative'], ['Selling, general & administrative', 'sellingGeneralAndAdministrative']],
+          remainder: 'Other / unallocated operating expenses',
+        },
+      };
+      function detailRows(spec, parentIdx, groupId, schedules, periods) {
+        const rows = spec.items.map(([label, field]) => {
+          if (!periods.some((p) => p[field] != null)) return '';
+          const cells = periods.map((p) => `<td>${p[field] == null ? '<span class="na">—</span>' : esc(fmtByUnit('USD', p[field]))}</td>`).join('');
+          return `<tr class="bs-detail" data-detailof="${groupId}" style="display:none"><td class="metric" style="padding-left:3rem">↳ ${esc(label)}</td>${cells}</tr>`;
+        }).join('');
+        let rem = '';
+        if (spec.remainder) {
+          const cells = periods.map((p, i) => {
+            const parent = schedules[i].lines[parentIdx].value;
+            const mapped = spec.items.reduce((s, [, f]) => s + (p[f] != null ? p[f] : 0), 0);
+            const v = parent == null ? null : parent - mapped;
+            return `<td>${v == null ? '<span class="na">—</span>' : esc(fmtByUnit('USD', v))}</td>`;
+          }).join('');
+          rem = `<tr class="bs-detail" data-detailof="${groupId}" style="display:none"><td class="metric" style="padding-left:3rem">↳ ${esc(spec.remainder)}</td>${cells}</tr>`;
+        }
+        return rows + rem;
+      }
+      function renderScheduleTable(title, schedules, periods, yearHeads, legend, detailMap, prefix) {
         const lines = schedules[0].lines;
         const body = lines.map((ln, idx) => {
           const cls = { header: 'bs-header', subtotal: 'bs-subtotal', grandtotal: 'bs-grand', sub: 'bs-sub', item: 'bs-item' }[ln.kind] || '';
@@ -499,7 +533,13 @@
                 const c = s.lines[idx];
                 return `<td>${c.value == null ? '<span class="na">—</span>' : esc(fmtByUnit(c.unit || 'USD', c.value))}</td>`;
               }).join('');
-          return `<tr class="${cls}"><td class="metric" style="padding-left:${pad}rem">${esc(ln.label)}</td>${cells}</tr>`;
+          const spec = detailMap && ln.key ? detailMap[ln.key] : null;
+          const groupId = spec ? `${prefix}-${ln.key}` : '';
+          const caret = spec ? '<span class="caret">▸</span> ' : '';
+          let row = `<tr class="${cls}${spec ? ' drill' : ''}"${spec ? ` data-drill="${groupId}"` : ''}>` +
+            `<td class="metric" style="padding-left:${pad}rem">${caret}${esc(ln.label)}</td>${cells}</tr>`;
+          if (spec) row += detailRows(spec, idx, groupId, schedules, periods);
+          return row;
         }).join('');
         return `<section class="group"><h2>${esc(title)}</h2><div class="scroll"><table>` +
           `<thead><tr><th class="metric">Particulars</th>${yearHeads}</tr></thead><tbody>${body}</tbody></table></div>` +
@@ -510,7 +550,8 @@
         return renderScheduleTable(
           'Statement of Profit & Loss — Companies Act 2013, Schedule III',
           periods.map(scheduleIIIPL), periods, yearHeads,
-          'US-GAAP (functional) expenses recast into Schedule III natural heads; "Other expenses" absorbs operating costs (R&D, sales & marketing, G&A) and embedded D&A so Total Income − Total Expenses = Profit Before Tax.'
+          'Click a ▸ line (e.g. Other expenses) to expand its detail. US-GAAP (functional) expenses are recast into Schedule III natural heads; "Other expenses" absorbs operating costs (R&D, sales & marketing, G&A) and embedded D&A so Total Income − Total Expenses = Profit Before Tax.',
+          PL_DETAIL, 'il'
         );
       }
 
@@ -1121,6 +1162,19 @@
       // ---- wiring -----------------------------------------------------------
       document.getElementById('api').value = defaultApiBase();
       document.getElementById('segBtn').addEventListener('click', loadSegments);
+      // Drill-down: clicking a ▸ heading toggles its detail rows (delegated so it
+      // survives re-renders).
+      document.addEventListener('click', (e) => {
+        const tr = e.target.closest && e.target.closest('tr.drill');
+        if (!tr) return;
+        const id = tr.getAttribute('data-drill');
+        const open = tr.classList.toggle('open');
+        document.querySelectorAll('tr.bs-detail[data-detailof="' + id + '"]').forEach((r) => {
+          r.style.display = open ? '' : 'none';
+        });
+        const caret = tr.querySelector('.caret');
+        if (caret) caret.textContent = open ? '▾' : '▸';
+      });
       fetchBtn.addEventListener('click', fetchLive);
       demoBtn.addEventListener('click', loadDemo);
       document.getElementById('allFactsBtn').addEventListener('click', loadAllFacts);

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -964,15 +964,19 @@
         if (!waccPeriod) return;
         const beta = parseFloat(document.getElementById('wBeta').value);
         const rfPct = document.getElementById('wRf').value, erpPct = document.getElementById('wErp').value;
-        const mc = parseFloat(document.getElementById('wMc').value);
+        const mcInput = parseFloat(document.getElementById('wMc').value);
+        // Fall back to book equity so WACC always computes (flagged in the note).
+        const bookEq = isFinite(waccPeriod.stockholdersEquity) ? waccPeriod.stockholdersEquity : null;
+        const eqUsed = isFinite(mcInput) ? mcInput : bookEq;
+        const eqBasis = isFinite(mcInput) ? 'market' : 'book';
         waccState.beta = isFinite(beta) ? beta : null;
-        waccState.marketCap = isFinite(mc) ? mc : null;
+        waccState.marketCap = isFinite(mcInput) ? mcInput : null;
         waccState.rf = rfPct; waccState.erp = erpPct;
         const r = computeWaccClient(waccPeriod, {
           beta: isFinite(beta) ? beta : null,
           rf: isFinite(parseFloat(rfPct)) ? parseFloat(rfPct) / 100 : null,
           erp: isFinite(parseFloat(erpPct)) ? parseFloat(erpPct) / 100 : null,
-          marketCap: isFinite(mc) ? mc : null,
+          marketCap: eqUsed,
         });
         const p2 = (v) => (v == null ? '—' : (v * 100).toFixed(2) + '%');
         document.getElementById('waccOut').innerHTML = [
@@ -983,11 +987,12 @@
           kpi('Tax rate', pctStr(r.taxRate)),
           kpi('Equity weight', pctStr(r.we)),
           kpi('Debt weight', pctStr(r.wd)),
-          kpi('Equity (market cap)', moneyStr(isFinite(mc) ? mc : null)),
+          kpi('Equity (' + eqBasis + ')', moneyStr(eqUsed)),
           kpi('Total debt (book)', moneyStr(r.totalDebt)),
         ].join('');
-        const notes = ['Cost of debt, tax rate and book debt are SEC-derived; β and market cap come from the market-data provider or your input; risk-free defaults to the US Treasury 10-yr (override above).'];
-        if (r.costOfDebt == null) notes.push('This company did not report interest expense and/or debt, so pre-tax cost of debt is blank — enter it manually if known.');
+        const notes = ['Cost of debt, tax rate and book debt are SEC-derived; β is an industry beta; risk-free defaults to the US Treasury 10-yr (override above).'];
+        if (eqBasis === 'book') notes.push('Market cap unavailable — equity weight uses BOOK equity. Enter Market cap above for proper market weights.');
+        if (r.costOfDebt == null) notes.push('No interest expense/debt reported, so pre-tax cost of debt is blank — enter it manually if known.');
         document.getElementById('waccNote').textContent = notes.join(' ');
       }
       async function fetchWaccInputs() {
@@ -1016,8 +1021,8 @@
           }
           const mc = data.inputs.marketValueOfEquity;
           note += mc != null
-            ? `Market cap (equity) = ${fmtByUnit('USD', mc)} via ${data.meta.marketCapSource || 'provided'}. Market value of equity is normally far larger than book equity.`
-            : 'Market cap unavailable — enter it manually for the equity weight.';
+            ? `Market cap (equity) = ${fmtByUnit('USD', mc)} via ${data.meta.marketCapSource || 'provided'}.`
+            : `Market cap not fetched (${data.meta.priceError || 'no source'}); WACC above uses BOOK equity — type a market cap for market weights.`;
           document.getElementById('waccNote').textContent = note;
         } catch (err) {
           document.getElementById('waccNote').textContent = 'Fetch error: ' + err.message;

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -148,6 +148,16 @@
         <div id="ratiosSection"></div>
         <div id="waccSection"></div>
 
+        <section class="group" id="segmentsSection">
+          <h2>Segment / Geographic / Product Revenue</h2>
+          <div class="allctrl">
+            <button id="segBtn" class="ghost" type="button">Load segment revenue</button>
+            <span class="count" id="segCount"></span>
+          </div>
+          <div id="segTables"></div>
+          <p class="legend" id="segNote"></p>
+        </section>
+
         <section class="group" id="allFactsSection">
           <h2>All reported facts — everything SEC has</h2>
           <div class="allctrl">
@@ -312,6 +322,7 @@
         document.getElementById('result').classList.remove('hidden');
         lastData = data;
         resetAllFacts();
+        resetSegments();
       }
 
       // ---- all reported facts ----------------------------------------------
@@ -432,6 +443,7 @@
         const d = buildDemo();
         render(d);
         renderProfile(DEMO_PROFILE, d.periods);
+        renderSegments(DEMO_SEGMENTS);
       }
 
       // ---- bundled sample dataset ------------------------------------------
@@ -732,8 +744,79 @@
         }
       }
 
+      // ---- segments ---------------------------------------------------------
+      const DEMO_SEGMENTS = {
+        accessionNumber: '0001065280-25-000044', reportDate: '2024-12-31', sourceDocument: '(sample data)',
+        fiscalYears: [2024, 2023],
+        axes: [{
+          axis: 'srt:StatementGeographicalAxis', label: 'Geographical (Region)',
+          members: [
+            { member: 'UCAN', label: 'United States & Canada', values: { 2024: 17359000000, 2023: 14874000000 } },
+            { member: 'EMEA', label: 'Europe, Middle East & Africa', values: { 2024: 12387000000, 2023: 10557000000 } },
+            { member: 'LATAM', label: 'Latin America', values: { 2024: 4896000000, 2023: 4489000000 } },
+            { member: 'APAC', label: 'Asia-Pacific', values: { 2024: 4358000000, 2023: 3763000000 } },
+          ],
+        }],
+      };
+      function resetSegments() {
+        document.getElementById('segTables').innerHTML = '';
+        document.getElementById('segCount').textContent = '';
+        document.getElementById('segNote').textContent = '';
+        const b = document.getElementById('segBtn');
+        if (b) b.disabled = false;
+      }
+      function renderSegments(data) {
+        const note = document.getElementById('segNote');
+        if (!data.axes || !data.axes.length) {
+          document.getElementById('segTables').innerHTML = '';
+          note.textContent = data.note || 'No single-axis revenue breakdowns found in the latest 10-K.';
+          document.getElementById('segCount').textContent = '';
+          return;
+        }
+        const years = data.fiscalYears;
+        document.getElementById('segTables').innerHTML = data.axes.map((ax) => {
+          const yearHeads = years.map((y) => `<th>FY ${y}</th>`).join('');
+          const rows = ax.members.map((m) => {
+            const cells = years.map((y) => {
+              const v = m.values[y];
+              return `<td>${v == null ? '<span class="na">—</span>' : esc(fmtByUnit('USD', v))}</td>`;
+            }).join('');
+            return `<tr><td class="metric">${esc(m.label)}</td>${cells}</tr>`;
+          }).join('');
+          return `<div style="margin-bottom:0.9rem"><div class="muted" style="margin:0.2rem 0">${esc(ax.label)} — <code class="tagname">${esc(ax.axis)}</code></div>` +
+            `<div class="scroll"><table><thead><tr><th class="metric">Member</th>${yearHeads}</tr></thead><tbody>${rows}</tbody></table></div></div>`;
+        }).join('');
+        const src = data.sourceDocument && data.sourceDocument.startsWith('http')
+          ? ` · <a href="${esc(data.sourceDocument)}" target="_blank" rel="noopener" style="color:var(--accent)">source 10-K</a>` : '';
+        note.innerHTML = `Parsed from the latest 10-K inline XBRL (${esc(data.accessionNumber || '')})${src}. Only single-axis full-year breakdowns are shown; product×geography intersection cells are excluded to avoid double-counting.`;
+        document.getElementById('segCount').textContent = data.axes.length + ' breakdown(s)';
+      }
+      async function loadSegments() {
+        if (isDemo) {
+          renderSegments(DEMO_SEGMENTS);
+          document.getElementById('segNote').textContent =
+            'Sample segment data (approximate Netflix regions). Load live data for the real breakdown parsed from the filing.';
+          return;
+        }
+        const btn = document.getElementById('segBtn');
+        btn.disabled = true;
+        document.getElementById('segNote').textContent =
+          'Fetching and parsing the latest 10-K inline XBRL (this can take a few seconds)…';
+        try {
+          const res = await fetch(apiBase() + '/api/sec/segments?ticker=' + encodeURIComponent(currentTicker));
+          const data = await res.json();
+          if (!res.ok) throw new Error(data.error || ('Request failed (' + res.status + ')'));
+          renderSegments(data);
+        } catch (err) {
+          document.getElementById('segNote').textContent = 'Error: ' + err.message;
+        } finally {
+          btn.disabled = false;
+        }
+      }
+
       // ---- wiring -----------------------------------------------------------
       document.getElementById('api').value = defaultApiBase();
+      document.getElementById('segBtn').addEventListener('click', loadSegments);
       fetchBtn.addEventListener('click', fetchLive);
       demoBtn.addEventListener('click', loadDemo);
       document.getElementById('allFactsBtn').addEventListener('click', loadAllFacts);

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -222,12 +222,17 @@
         ['propertyPlantEquipmentNet', 'PP&E, Net', 'bs', 'USD'],
         ['goodwill', 'Goodwill', 'bs', 'USD'],
         ['intangibleAssets', 'Intangible Assets', 'bs', 'USD'],
+        ['otherNoncurrentAssets', 'Other Non-Current Assets', 'bs', 'USD'],
         ['totalAssets', 'Total Assets', 'bs', 'USD'],
         ['accountsPayable', 'Accounts Payable', 'bs', 'USD'],
+        ['accruedLiabilities', 'Accrued Liabilities', 'bs', 'USD'],
+        ['otherCurrentLiabilities', 'Other Current Liabilities', 'bs', 'USD'],
         ['shortTermDebt', 'Short-Term / Current Debt', 'bs', 'USD'],
         ['deferredRevenueCurrent', 'Deferred Revenue (Current)', 'bs', 'USD'],
         ['currentLiabilities', 'Total Current Liabilities', 'bs', 'USD'],
         ['longTermDebt', 'Long-Term Debt', 'bs', 'USD'],
+        ['otherNoncurrentLiabilities', 'Other Non-Current Liabilities', 'bs', 'USD'],
+        ['deferredTaxLiabilities', 'Deferred Tax Liabilities', 'bs', 'USD'],
         ['totalLiabilities', 'Total Liabilities', 'bs', 'USD'],
         ['commonStockValue', 'Common Stock', 'bs', 'USD'],
         ['additionalPaidInCapital', 'Additional Paid-In Capital', 'bs', 'USD'],
@@ -236,7 +241,11 @@
         ['accumulatedOCI', 'Accumulated OCI', 'bs', 'USD'],
         ['stockholdersEquity', "Stockholders' Equity", 'bs', 'USD'],
         ['depreciationAmortization', 'Depreciation & Amortization', 'cf', 'USD'],
+        ['amortizationOfIntangibles', 'Amortization of Intangibles/Content', 'cf', 'USD'],
         ['stockBasedCompensation', 'Stock-Based Compensation', 'cf', 'USD'],
+        ['deferredIncomeTaxes', 'Deferred Income Taxes', 'cf', 'USD'],
+        ['otherNoncashItems', 'Other Non-Cash Items', 'cf', 'USD'],
+        ['changeInWorkingCapital', 'Change in Working Capital', 'cf', 'USD'],
         ['operatingCashFlow', 'Operating Cash Flow', 'cf', 'USD'],
         ['capitalExpenditure', 'Capital Expenditure', 'cf', 'USD'],
         ['acquisitions', 'Acquisitions, Net', 'cf', 'USD'],
@@ -244,8 +253,11 @@
         ['debtIssued', 'Debt Issued', 'cf', 'USD'],
         ['debtRepaid', 'Debt Repaid', 'cf', 'USD'],
         ['stockRepurchased', 'Stock Repurchased', 'cf', 'USD'],
+        ['stockIssued', 'Stock Issued', 'cf', 'USD'],
         ['dividendsPaid', 'Dividends Paid', 'cf', 'USD'],
         ['financingCashFlow', 'Financing Cash Flow', 'cf', 'USD'],
+        ['effectOfExchangeRate', 'Effect of Exchange Rate on Cash', 'cf', 'USD'],
+        ['netChangeInCash', 'Net Change in Cash', 'cf', 'USD'],
       ];
       const GROUP_TITLES = { inc: 'Income Statement', ps: 'Per Share', bs: 'Balance Sheet', cf: 'Cash Flow' };
       const GROUP_ORDER = ['inc', 'ps', 'bs', 'cf'];
@@ -315,7 +327,10 @@
             `<thead><tr><th class="metric">Metric</th>${yearHeads}</tr></thead><tbody>${rows}</tbody></table></div></section>`;
         }).join('');
 
-        document.getElementById('sections').innerHTML = filingsHtml + groupsHtml;
+        const warnHtml = (data.warnings || [])
+          .map((w) => `<div class="banner">⚠ ${esc(w)}</div>`)
+          .join('');
+        document.getElementById('sections').innerHTML = warnHtml + filingsHtml + groupsHtml;
         renderRatios(periods);
         initWacc(periods[0]);
         document.getElementById('raw').textContent = JSON.stringify(data, null, 2);

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -124,7 +124,8 @@
       <div class="controls">
         <div class="field">
           <label for="ticker">Ticker</label>
-          <input id="ticker" value="NFLX" autocomplete="off" placeholder="NFLX" />
+          <input id="ticker" list="tickerList" value="NFLX" placeholder="NFLX" autocomplete="off" />
+          <datalist id="tickerList"></datalist>
         </div>
         <div class="field">
           <label for="years">Periods</label>
@@ -1159,8 +1160,41 @@
         }
       }
 
+      // ~100 NASDAQ-100 / large-cap NASDAQ tickers for the ticker dropdown.
+      // Any other ticker can still be typed in.
+      const NASDAQ_TICKERS = [
+        ['AAPL', 'Apple Inc.'], ['MSFT', 'Microsoft'], ['NVDA', 'NVIDIA'], ['AMZN', 'Amazon.com'],
+        ['GOOGL', 'Alphabet (Class A)'], ['GOOG', 'Alphabet (Class C)'], ['META', 'Meta Platforms'],
+        ['AVGO', 'Broadcom'], ['TSLA', 'Tesla'], ['COST', 'Costco Wholesale'], ['NFLX', 'Netflix'],
+        ['ADBE', 'Adobe'], ['PEP', 'PepsiCo'], ['AMD', 'Advanced Micro Devices'], ['CSCO', 'Cisco Systems'],
+        ['TMUS', 'T-Mobile US'], ['INTC', 'Intel'], ['CMCSA', 'Comcast'], ['INTU', 'Intuit'],
+        ['QCOM', 'Qualcomm'], ['AMGN', 'Amgen'], ['TXN', 'Texas Instruments'], ['HON', 'Honeywell'],
+        ['AMAT', 'Applied Materials'], ['ISRG', 'Intuitive Surgical'], ['BKNG', 'Booking Holdings'],
+        ['VRTX', 'Vertex Pharmaceuticals'], ['ADP', 'Automatic Data Processing'], ['GILD', 'Gilead Sciences'],
+        ['ADI', 'Analog Devices'], ['REGN', 'Regeneron Pharmaceuticals'], ['MDLZ', 'Mondelez International'],
+        ['MELI', 'MercadoLibre'], ['LRCX', 'Lam Research'], ['PANW', 'Palo Alto Networks'], ['SBUX', 'Starbucks'],
+        ['KLAC', 'KLA Corporation'], ['SNPS', 'Synopsys'], ['CDNS', 'Cadence Design Systems'], ['CRWD', 'CrowdStrike'],
+        ['MAR', 'Marriott International'], ['ABNB', 'Airbnb'], ['ORLY', "O'Reilly Automotive"], ['CSX', 'CSX Corporation'],
+        ['ASML', 'ASML Holding'], ['CTAS', 'Cintas'], ['NXPI', 'NXP Semiconductors'], ['PYPL', 'PayPal'],
+        ['MNST', 'Monster Beverage'], ['WDAY', 'Workday'], ['MRVL', 'Marvell Technology'], ['FTNT', 'Fortinet'],
+        ['ADSK', 'Autodesk'], ['PCAR', 'PACCAR'], ['ROP', 'Roper Technologies'], ['CPRT', 'Copart'],
+        ['PAYX', 'Paychex'], ['KDP', 'Keurig Dr Pepper'], ['MCHP', 'Microchip Technology'], ['AEP', 'American Electric Power'],
+        ['DXCM', 'DexCom'], ['IDXX', 'IDEXX Laboratories'], ['ROST', 'Ross Stores'], ['KHC', 'Kraft Heinz'],
+        ['FAST', 'Fastenal'], ['EA', 'Electronic Arts'], ['BKR', 'Baker Hughes'], ['GEHC', 'GE HealthCare'],
+        ['CCEP', 'Coca-Cola Europacific Partners'], ['EXC', 'Exelon'], ['VRSK', 'Verisk Analytics'],
+        ['CTSH', 'Cognizant Technology'], ['XEL', 'Xcel Energy'], ['CSGP', 'CoStar Group'], ['ON', 'ON Semiconductor'],
+        ['TTD', 'The Trade Desk'], ['DASH', 'DoorDash'], ['BIIB', 'Biogen'], ['ANSS', 'Ansys'], ['ZS', 'Zscaler'],
+        ['DDOG', 'Datadog'], ['TEAM', 'Atlassian'], ['WBD', 'Warner Bros. Discovery'], ['ILMN', 'Illumina'],
+        ['GFS', 'GlobalFoundries'], ['MDB', 'MongoDB'], ['LULU', 'Lululemon Athletica'], ['FANG', 'Diamondback Energy'],
+        ['SIRI', 'Sirius XM'], ['ALGN', 'Align Technology'], ['ARM', 'Arm Holdings'], ['SMCI', 'Super Micro Computer'],
+        ['MRNA', 'Moderna'], ['DLTR', 'Dollar Tree'], ['EBAY', 'eBay'], ['CDW', 'CDW Corporation'],
+        ['TTWO', 'Take-Two Interactive'], ['ZM', 'Zoom Communications'], ['OKTA', 'Okta'], ['PDD', 'PDD Holdings'],
+      ];
+
       // ---- wiring -----------------------------------------------------------
       document.getElementById('api').value = defaultApiBase();
+      document.getElementById('tickerList').innerHTML =
+        NASDAQ_TICKERS.map(([t, name]) => `<option value="${t}">${esc(name)}</option>`).join('');
       document.getElementById('segBtn').addEventListener('click', loadSegments);
       // Drill-down: clicking a ▸ heading toggles its detail rows (delegated so it
       // survives re-renders).

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -6,190 +6,405 @@
     <title>SEC EDGAR 10-K Financials</title>
     <style>
       :root {
-        --bg: #0f172a;
-        --panel: #1e293b;
-        --line: #334155;
-        --text: #e2e8f0;
-        --muted: #94a3b8;
-        --accent: #38bdf8;
-        --error: #f87171;
+        --bg: #0b1120;
+        --panel: #111c33;
+        --panel2: #16243f;
+        --line: #2b3b5b;
+        --text: #e6edf6;
+        --muted: #8aa0c0;
+        --accent: #4cc4ff;
+        --good: #4ade80;
+        --bad: #f87171;
+        --warn: #fbbf24;
       }
       * { box-sizing: border-box; }
       body {
         margin: 0;
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-        background: var(--bg);
+        background: radial-gradient(1200px 600px at 80% -10%, #15233f 0%, var(--bg) 55%);
         color: var(--text);
-        padding: 2rem 1rem;
+        min-height: 100vh;
+        padding: 2rem 1rem 4rem;
       }
-      .wrap { max-width: 1100px; margin: 0 auto; }
-      h1 { font-size: 1.4rem; margin: 0 0 0.25rem; }
-      p.sub { color: var(--muted); margin: 0 0 1.5rem; font-size: 0.9rem; }
-      form { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; margin-bottom: 1rem; }
+      .wrap { max-width: 1180px; margin: 0 auto; }
+      header.app { margin-bottom: 1.25rem; }
+      h1 { font-size: 1.5rem; margin: 0 0 0.25rem; }
+      p.sub { color: var(--muted); margin: 0; font-size: 0.9rem; max-width: 760px; }
+
+      .controls {
+        display: flex; gap: 0.6rem; flex-wrap: wrap; align-items: flex-end;
+        background: var(--panel); border: 1px solid var(--line); border-radius: 12px;
+        padding: 1rem; margin: 1.25rem 0;
+      }
+      .field { display: flex; flex-direction: column; gap: 0.3rem; }
+      .field label { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted); }
       input, button, select {
-        background: var(--panel);
-        color: var(--text);
-        border: 1px solid var(--line);
-        border-radius: 6px;
-        padding: 0.55rem 0.75rem;
-        font-size: 0.95rem;
+        background: var(--panel2); color: var(--text); border: 1px solid var(--line);
+        border-radius: 8px; padding: 0.6rem 0.7rem; font-size: 0.95rem;
       }
-      input { text-transform: uppercase; width: 130px; }
-      button { cursor: pointer; border-color: var(--accent); color: var(--accent); font-weight: 600; }
+      input#ticker { text-transform: uppercase; width: 120px; font-weight: 700; letter-spacing: 0.05em; }
+      input#api { width: 230px; }
+      button { cursor: pointer; font-weight: 700; }
+      button.primary { background: var(--accent); color: #04243a; border-color: var(--accent); }
+      button.ghost { color: var(--accent); }
       button:disabled { opacity: 0.5; cursor: not-allowed; }
-      .status { margin: 1rem 0; font-size: 0.95rem; }
-      .status.error { color: var(--error); }
-      .meta { color: var(--muted); font-size: 0.85rem; margin-bottom: 0.75rem; }
-      table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
-      th, td { border: 1px solid var(--line); padding: 0.5rem 0.6rem; text-align: right; white-space: nowrap; }
-      th:first-child, td:first-child { text-align: left; position: sticky; left: 0; background: var(--panel); }
-      thead th { background: var(--panel); position: sticky; top: 0; }
-      .scroll { overflow-x: auto; border: 1px solid var(--line); border-radius: 8px; }
-      .tag { cursor: help; border-bottom: 1px dotted var(--muted); }
-      .row-label { color: var(--muted); cursor: pointer; }
-      details { margin-top: 1.5rem; }
-      summary { cursor: pointer; color: var(--accent); }
-      pre { background: var(--panel); padding: 1rem; border-radius: 8px; overflow: auto; font-size: 0.75rem; max-height: 360px; }
-      .audit td { color: var(--muted); font-size: 0.72rem; }
+
+      .status { margin: 0.5rem 0 1rem; font-size: 0.95rem; min-height: 1.2rem; }
+      .status.error { color: var(--bad); }
+      .status.loading { color: var(--accent); }
+      .banner {
+        background: rgba(251, 191, 36, 0.12); border: 1px solid var(--warn); color: var(--warn);
+        padding: 0.55rem 0.8rem; border-radius: 8px; font-size: 0.82rem; margin-bottom: 1rem;
+      }
+
+      .company {
+        display: flex; flex-wrap: wrap; gap: 1.5rem; align-items: baseline;
+        border-bottom: 1px solid var(--line); padding-bottom: 0.9rem; margin-bottom: 1.25rem;
+      }
+      .company .name { font-size: 1.35rem; font-weight: 800; }
+      .company .pill {
+        font-size: 0.72rem; color: var(--muted);
+        border: 1px solid var(--line); border-radius: 999px; padding: 0.15rem 0.6rem;
+      }
+
+      section.group { margin-bottom: 1.6rem; }
+      section.group > h2 {
+        font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.08em;
+        color: var(--accent); margin: 0 0 0.5rem;
+      }
+      .scroll { overflow-x: auto; border: 1px solid var(--line); border-radius: 10px; }
+      table { width: 100%; border-collapse: collapse; font-size: 0.86rem; }
+      th, td { padding: 0.55rem 0.7rem; text-align: right; white-space: nowrap; border-bottom: 1px solid var(--line); }
+      thead th { background: var(--panel); color: var(--muted); font-weight: 600; position: sticky; top: 0; }
+      tbody tr:hover { background: rgba(76, 196, 255, 0.06); }
+      th.metric, td.metric {
+        text-align: left; position: sticky; left: 0; background: var(--panel);
+        font-weight: 600; min-width: 190px;
+      }
+      tbody tr:hover td.metric { background: var(--panel2); }
+      td .val { font-variant-numeric: tabular-nums; }
+      td .tag {
+        display: block; font-size: 0.68rem; color: var(--muted); margin-top: 0.1rem;
+        cursor: help; border-bottom: 1px dotted transparent;
+      }
+      td .tag:hover { border-bottom-color: var(--muted); }
+      td.derived .val::after { content: " ∗"; color: var(--warn); }
+      .na { color: #56688a; }
+
+      details.raw { margin-top: 1.5rem; }
+      details.raw summary { cursor: pointer; color: var(--accent); font-weight: 600; }
+      pre { background: var(--panel); border: 1px solid var(--line); padding: 1rem; border-radius: 10px; overflow: auto; font-size: 0.74rem; max-height: 420px; }
+      .legend { color: var(--muted); font-size: 0.76rem; margin-top: 0.6rem; }
+      .hidden { display: none; }
     </style>
   </head>
   <body>
     <div class="wrap">
-      <h1>SEC EDGAR 10-K Financials</h1>
-      <p class="sub">
-        Structured annual financial data pulled from the official SEC EDGAR XBRL JSON APIs.
-        No PDF extraction, no API key. Hover a value to see the raw US-GAAP tag used.
-      </p>
+      <header class="app">
+        <h1>SEC EDGAR · 10-K Financials</h1>
+        <p class="sub">
+          Structured annual financial-statement data pulled from the official SEC EDGAR
+          XBRL JSON APIs — no API key, no PDF extraction. Every figure links back to the
+          exact US-GAAP tag it came from (shown beneath each value).
+        </p>
+      </header>
 
-      <form id="form">
-        <input id="ticker" name="ticker" placeholder="NFLX" value="NFLX" autocomplete="off" />
-        <select id="years" name="years">
-          <option value="">All years</option>
-          <option value="3">Last 3</option>
-          <option value="5" selected>Last 5</option>
-          <option value="10">Last 10</option>
-        </select>
-        <button id="submit" type="submit">Fetch</button>
-      </form>
-
-      <div id="status" class="status"></div>
-      <div id="meta" class="meta"></div>
-      <div id="result" class="scroll" hidden>
-        <table id="table">
-          <thead>
-            <tr id="head"></tr>
-          </thead>
-          <tbody id="body"></tbody>
-        </table>
+      <div class="controls">
+        <div class="field">
+          <label for="ticker">Ticker</label>
+          <input id="ticker" value="NFLX" autocomplete="off" placeholder="NFLX" />
+        </div>
+        <div class="field">
+          <label for="years">Periods</label>
+          <select id="years">
+            <option value="">All years</option>
+            <option value="3">Last 3</option>
+            <option value="5" selected>Last 5</option>
+            <option value="10">Last 10</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="api">Backend URL</label>
+          <input id="api" placeholder="http://localhost:3000" />
+        </div>
+        <div class="field">
+          <label>&nbsp;</label>
+          <button id="fetchBtn" class="primary" type="button">Fetch live data</button>
+        </div>
+        <div class="field">
+          <label>&nbsp;</label>
+          <button id="demoBtn" class="ghost" type="button">Load sample data</button>
+        </div>
       </div>
 
-      <details id="rawWrap" hidden>
-        <summary>Raw normalized JSON (with per-value audit trail)</summary>
-        <pre id="raw"></pre>
-      </details>
+      <div id="status" class="status"></div>
+      <div id="banner" class="banner hidden"></div>
+
+      <div id="result" class="hidden">
+        <div class="company" id="company"></div>
+        <div id="sections"></div>
+
+        <p class="legend">
+          Hover the tag under any value to see its unit, filing accession number and filed date.
+          <strong>∗</strong> marks a derived value (e.g. total liabilities computed from current +
+          non-current). <span class="na">—</span> means the company did not report that tag for
+          the period.
+        </p>
+
+        <details class="raw">
+          <summary>Raw normalized JSON (full audit trail)</summary>
+          <pre id="raw"></pre>
+        </details>
+      </div>
     </div>
 
     <script>
-      const ROWS = [
-        ['revenue', 'Revenue'],
-        ['costOfRevenue', 'Cost of Revenue'],
-        ['grossProfit', 'Gross Profit'],
-        ['operatingIncome', 'Operating Income'],
-        ['netIncome', 'Net Income'],
-        ['totalAssets', 'Total Assets'],
-        ['currentAssets', 'Current Assets'],
-        ['cashAndEquivalents', 'Cash & Equivalents'],
-        ['totalLiabilities', 'Total Liabilities'],
-        ['stockholdersEquity', "Stockholders' Equity"],
-        ['operatingCashFlow', 'Operating Cash Flow'],
-        ['capitalExpenditure', 'Capital Expenditure'],
-        ['dilutedEPS', 'Diluted EPS'],
-        ['dilutedShares', 'Diluted Shares'],
+      // ---- field groups / formatting ---------------------------------------
+      const GROUPS = [
+        { title: 'Income Statement', fields: [
+          ['revenue', 'Revenue', 'money'],
+          ['costOfRevenue', 'Cost of Revenue', 'money'],
+          ['grossProfit', 'Gross Profit', 'money'],
+          ['operatingIncome', 'Operating Income', 'money'],
+          ['netIncome', 'Net Income', 'money'],
+        ]},
+        { title: 'Balance Sheet', fields: [
+          ['totalAssets', 'Total Assets', 'money'],
+          ['currentAssets', 'Current Assets', 'money'],
+          ['cashAndEquivalents', 'Cash & Equivalents', 'money'],
+          ['totalLiabilities', 'Total Liabilities', 'money'],
+          ['stockholdersEquity', "Stockholders' Equity", 'money'],
+        ]},
+        { title: 'Cash Flow', fields: [
+          ['operatingCashFlow', 'Operating Cash Flow', 'money'],
+          ['capitalExpenditure', 'Capital Expenditure', 'money'],
+        ]},
+        { title: 'Per Share', fields: [
+          ['dilutedEPS', 'Diluted EPS', 'eps'],
+          ['dilutedShares', 'Diluted Shares', 'shares'],
+        ]},
       ];
 
-      const form = document.getElementById('form');
-      const statusEl = document.getElementById('status');
-      const metaEl = document.getElementById('meta');
-      const resultEl = document.getElementById('result');
-      const headEl = document.getElementById('head');
-      const bodyEl = document.getElementById('body');
-      const rawWrap = document.getElementById('rawWrap');
-      const rawEl = document.getElementById('raw');
-      const submitBtn = document.getElementById('submit');
-
-      function fmt(field, value) {
-        if (value === null || value === undefined) return '—';
-        if (field === 'dilutedEPS') return value.toFixed(2);
-        if (field === 'dilutedShares') return value.toLocaleString();
-        const abs = Math.abs(value);
-        if (abs >= 1e9) return (value / 1e9).toFixed(2) + 'B';
-        if (abs >= 1e6) return (value / 1e6).toFixed(2) + 'M';
-        return value.toLocaleString();
+      function fmt(kind, v) {
+        if (v === null || v === undefined) return null;
+        if (kind === 'eps') return '$' + Number(v).toFixed(2);
+        if (kind === 'shares') {
+          const a = Math.abs(v);
+          if (a >= 1e9) return (v / 1e9).toFixed(2) + 'B';
+          if (a >= 1e6) return (v / 1e6).toFixed(1) + 'M';
+          return Number(v).toLocaleString();
+        }
+        // money
+        const sign = v < 0 ? '-' : '';
+        const a = Math.abs(v);
+        if (a >= 1e9) return sign + '$' + (a / 1e9).toFixed(2) + 'B';
+        if (a >= 1e6) return sign + '$' + (a / 1e6).toFixed(1) + 'M';
+        if (a >= 1e3) return sign + '$' + (a / 1e3).toFixed(0) + 'K';
+        return sign + '$' + a;
       }
 
+      const esc = (s) =>
+        String(s).replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+
+      // ---- rendering --------------------------------------------------------
       function render(data) {
-        metaEl.textContent =
-          `${data.companyName} — CIK ${data.cik} — ${data.periods.length} annual 10-K period(s)`;
+        const periods = data.periods || [];
+        document.getElementById('company').innerHTML = [
+          `<span class="name">${esc(data.companyName || data.ticker)}</span>`,
+          `<span class="pill">Ticker ${esc(data.ticker)}</span>`,
+          `<span class="pill">CIK ${esc(data.cik)}</span>`,
+          `<span class="pill">${periods.length} annual 10-K period(s)</span>`,
+        ].join('');
 
-        headEl.innerHTML = '<th>Metric</th>' +
-          data.periods.map((p) => `<th>FY${p.fiscalYear}</th>`).join('');
+        const yearHeads = periods.map((p) => `<th>FY ${p.fiscalYear}</th>`).join('');
+        const filedRow =
+          `<tr><td class="metric">Filed</td>` +
+          periods.map((p) => `<td class="na">${esc(p.filed || '—')}</td>`).join('') +
+          `</tr>`;
 
-        bodyEl.innerHTML = ROWS.map(([field, label]) => {
-          const cells = data.periods.map((p) => {
-            const audit = p.rawTagsUsed[field];
-            const title = audit
-              ? `tag: ${audit.tag}\nunit: ${audit.unit}\nfiled: ${audit.filed}\naccession: ${audit.accessionNumber}\nform: ${audit.form}`
-              : 'no data';
-            const cls = audit ? 'tag' : '';
-            return `<td><span class="${cls}" title="${title.replace(/"/g, '&quot;')}">${fmt(field, p[field])}</span></td>`;
-          });
-          return `<tr><td class="row-label">${label}</td>${cells.join('')}</tr>`;
+        const sectionsHtml = GROUPS.map((g) => {
+          const rows = g.fields.map(([field, label, kind]) => {
+            const cells = periods.map((p) => {
+              const raw = p[field];
+              const audit = p.rawTagsUsed ? p.rawTagsUsed[field] : null;
+              const text = fmt(kind, raw);
+              if (text === null) return `<td><span class="val na">—</span></td>`;
+              const derived = audit && audit.derived ? ' derived' : '';
+              const tip = audit
+                ? `tag: ${audit.tag}\nunit: ${audit.unit}\nfiscal year: ${audit.fiscalYear}\nfiled: ${audit.filed}\naccession: ${audit.accessionNumber}\nform: ${audit.form}\nexact value: ${raw}`
+                : `exact value: ${raw}`;
+              const tagLabel = audit ? esc(audit.tag) : '';
+              return (
+                `<td class="${derived}">` +
+                `<span class="val">${esc(text)}</span>` +
+                (tagLabel ? `<span class="tag" title="${esc(tip)}">${tagLabel}</span>` : '') +
+                `</td>`
+              );
+            }).join('');
+            return `<tr><td class="metric">${esc(label)}</td>${cells}</tr>`;
+          }).join('');
+
+          return (
+            `<section class="group"><h2>${esc(g.title)}</h2><div class="scroll"><table>` +
+            `<thead><tr><th class="metric">Metric</th>${yearHeads}</tr></thead>` +
+            `<tbody>${rows}</tbody></table></div></section>`
+          );
         }).join('');
 
-        const filedRow =
-          '<tr class="audit"><td>Filed</td>' +
-          data.periods.map((p) => `<td>${p.filed || '—'}</td>`).join('') +
-          '</tr>';
-        bodyEl.insertAdjacentHTML('beforeend', filedRow);
+        // Filings overview table on top.
+        const filingsHtml =
+          `<section class="group"><h2>Filings</h2><div class="scroll"><table>` +
+          `<thead><tr><th class="metric">Metric</th>${yearHeads}</tr></thead>` +
+          `<tbody>${filedRow}` +
+          `<tr><td class="metric">Accession #</td>` +
+          periods.map((p) => `<td class="na">${esc(p.accessionNumber || '—')}</td>`).join('') +
+          `</tr></tbody></table></div></section>`;
 
-        resultEl.hidden = false;
-        rawEl.textContent = JSON.stringify(data, null, 2);
-        rawWrap.hidden = false;
+        document.getElementById('sections').innerHTML = filingsHtml + sectionsHtml;
+        document.getElementById('raw').textContent = JSON.stringify(data, null, 2);
+        document.getElementById('result').classList.remove('hidden');
       }
 
-      async function run(ticker, years) {
-        statusEl.className = 'status';
-        statusEl.textContent = 'Loading…';
-        resultEl.hidden = true;
-        rawWrap.hidden = true;
-        metaEl.textContent = '';
-        submitBtn.disabled = true;
+      // ---- data sources -----------------------------------------------------
+      const statusEl = document.getElementById('status');
+      const bannerEl = document.getElementById('banner');
+      const fetchBtn = document.getElementById('fetchBtn');
+      const demoBtn = document.getElementById('demoBtn');
+
+      function setStatus(msg, kind) {
+        statusEl.className = 'status' + (kind ? ' ' + kind : '');
+        statusEl.textContent = msg || '';
+      }
+      function showBanner(msg) {
+        if (!msg) { bannerEl.classList.add('hidden'); return; }
+        bannerEl.textContent = msg;
+        bannerEl.classList.remove('hidden');
+      }
+
+      function defaultApiBase() {
+        if (location.protocol === 'http:' || location.protocol === 'https:') return location.origin;
+        return 'http://localhost:3000';
+      }
+
+      async function fetchLive() {
+        const ticker = document.getElementById('ticker').value.trim().toUpperCase();
+        const years = document.getElementById('years').value;
+        const base = (document.getElementById('api').value.trim() || defaultApiBase()).replace(/\/$/, '');
+        if (!ticker) { setStatus('Enter a ticker first.', 'error'); return; }
+
+        showBanner('');
+        setStatus('Loading ' + ticker + ' from ' + base + ' …', 'loading');
+        document.getElementById('result').classList.add('hidden');
+        fetchBtn.disabled = true;
         try {
           const params = new URLSearchParams({ ticker });
           if (years) params.set('years', years);
-          const res = await fetch(`/api/sec/model-data?${params.toString()}`);
+          const res = await fetch(base + '/api/sec/model-data?' + params.toString());
           const data = await res.json();
-          if (!res.ok) throw new Error(data.error || `Request failed (${res.status})`);
-          if (!data.periods.length) {
-            statusEl.textContent = 'No annual 10-K data found for this ticker.';
+          if (!res.ok) throw new Error(data.error || ('Request failed (' + res.status + ')'));
+          if (!data.periods || !data.periods.length) {
+            setStatus('No annual 10-K data found for ' + ticker + '.', 'error');
             return;
           }
-          statusEl.textContent = '';
+          setStatus('Loaded ' + ticker + ' — live SEC data.');
           render(data);
         } catch (err) {
-          statusEl.className = 'status error';
-          statusEl.textContent = `Error: ${err.message}`;
+          setStatus('Error: ' + err.message + ' — is the backend running at ' + base + '?', 'error');
         } finally {
-          submitBtn.disabled = false;
+          fetchBtn.disabled = false;
         }
       }
 
-      form.addEventListener('submit', (e) => {
-        e.preventDefault();
-        const ticker = document.getElementById('ticker').value.trim();
-        const years = document.getElementById('years').value;
-        if (ticker) run(ticker, years);
+      function loadDemo() {
+        showBanner('Sample data shown for layout preview — approximate Netflix figures, not a live SEC pull. Click "Fetch live data" against a running backend for real numbers.');
+        setStatus('');
+        render(buildDemo());
+      }
+
+      // ---- bundled sample dataset (normalized output shape) -----------------
+      function buildDemo() {
+        const FIELD_TAG = {
+          revenue: 'Revenues',
+          costOfRevenue: 'CostOfGoodsAndServicesSold',
+          grossProfit: 'GrossProfit',
+          operatingIncome: 'OperatingIncomeLoss',
+          netIncome: 'NetIncomeLoss',
+          totalAssets: 'Assets',
+          currentAssets: 'AssetsCurrent',
+          cashAndEquivalents: 'CashAndCashEquivalentsAtCarryingValue',
+          totalLiabilities: 'Liabilities',
+          stockholdersEquity: 'StockholdersEquity',
+          operatingCashFlow: 'NetCashProvidedByUsedInOperatingActivities',
+          capitalExpenditure: 'PaymentsToAcquirePropertyPlantAndEquipment',
+          dilutedEPS: 'EarningsPerShareDiluted',
+          dilutedShares: 'WeightedAverageNumberOfDilutedSharesOutstanding',
+        };
+        const UNIT = { dilutedEPS: 'USD/shares', dilutedShares: 'shares' };
+        const ALL = Object.keys(FIELD_TAG);
+
+        const RAW = [
+          { fy: 2024, filed: '2025-01-27', accn: '0001065280-25-000044', v: {
+            revenue: 39000966000, costOfRevenue: 21038000000, grossProfit: 17962966000,
+            operatingIncome: 10417874000, netIncome: 8711631000, totalAssets: 53629000000,
+            currentAssets: 9792000000, cashAndEquivalents: 7804000000, totalLiabilities: 28886000000,
+            stockholdersEquity: 24743000000, operatingCashFlow: 6921000000, capitalExpenditure: 439000000,
+            dilutedEPS: 19.83, dilutedShares: 439380000 } },
+          { fy: 2023, filed: '2024-01-26', accn: '0001065280-24-000029', v: {
+            revenue: 33723297000, costOfRevenue: 19715368000, grossProfit: 14007929000,
+            operatingIncome: 6954303000, netIncome: 5407990000, totalAssets: 48731992000,
+            currentAssets: 9918133000, cashAndEquivalents: 7116913000, totalLiabilities: 28107976000,
+            stockholdersEquity: 20624016000, operatingCashFlow: 7273885000, capitalExpenditure: 348428000,
+            dilutedEPS: 12.03, dilutedShares: 449498000 } },
+          { fy: 2022, filed: '2023-01-27', accn: '0001065280-23-000017', v: {
+            revenue: 31615550000, costOfRevenue: 19168285000, grossProfit: 12447265000,
+            operatingIncome: 5632831000, netIncome: 4491924000, totalAssets: 48594768000,
+            currentAssets: null, cashAndEquivalents: 5147176000, totalLiabilities: null,
+            stockholdersEquity: 20777401000, operatingCashFlow: 2021131000, capitalExpenditure: 407719000,
+            dilutedEPS: 9.95, dilutedShares: 451290000 } },
+          { fy: 2021, filed: '2022-01-28', accn: '0001065280-22-000036', v: {
+            revenue: 29697844000, costOfRevenue: null, grossProfit: null,
+            operatingIncome: 6194509000, netIncome: 5116228000, totalAssets: null,
+            currentAssets: null, cashAndEquivalents: 6027804000, totalLiabilities: null,
+            stockholdersEquity: 15849248000, operatingCashFlow: 392610000, capitalExpenditure: 524585000,
+            dilutedEPS: 11.24, dilutedShares: 455372000 } },
+        ];
+
+        const periods = RAW.map((p) => {
+          const period = { fiscalYear: p.fy, form: '10-K', filed: p.filed, accessionNumber: p.accn };
+          const rawTagsUsed = {};
+          for (const field of ALL) {
+            const val = p.v[field];
+            period[field] = val === undefined ? null : val;
+            if (val === null || val === undefined) continue;
+            rawTagsUsed[field] = {
+              tag: FIELD_TAG[field],
+              unit: UNIT[field] || 'USD',
+              value: val,
+              fiscalYear: p.fy,
+              reportFiscalYear: p.fy,
+              accessionNumber: p.accn,
+              filed: p.filed,
+              form: '10-K',
+              periodEnd: p.fy + '-12-31',
+            };
+          }
+          period.rawTagsUsed = rawTagsUsed;
+          return period;
+        });
+
+        return { ticker: 'NFLX', cik: '0001065280', companyName: 'NETFLIX INC', periods };
+      }
+
+      // ---- wiring -----------------------------------------------------------
+      document.getElementById('api').value = defaultApiBase();
+      fetchBtn.addEventListener('click', fetchLive);
+      demoBtn.addEventListener('click', loadDemo);
+      document.getElementById('ticker').addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') fetchLive();
       });
+
+      // Show the sample table immediately so the formatting is visible on load.
+      loadDemo();
     </script>
   </body>
 </html>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -442,6 +442,78 @@
           `<p class="legend">Recast from US-GAAP into Schedule III buckets. SEC-reported control totals are authoritative; "Other …" lines absorb company-specific items (e.g. content liabilities) so every subtotal and the grand total reconcile.</p></section>`;
       }
 
+      // Schedule III, Part II — Statement of Profit & Loss (mirrors
+      // server/src/incomeStatement.js): anchor on PBT, "Other expenses" plugs
+      // the functional operating costs so Total Income − Total Expenses = PBT.
+      function scheduleIIIPL(period) {
+        const v = period || {};
+        const n = (x) => (typeof x === 'number' && isFinite(x) ? x : null);
+        const add = (arr) => { let s = 0, any = false; for (const x of arr) if (x != null) { s += x; any = true; } return any ? s : null; };
+
+        const revenue = n(v.revenue);
+        const otherIncome = add([n(v.interestIncome), n(v.otherIncomeExpense)]);
+        const totalIncome = add([revenue, otherIncome]);
+        let pbt = n(v.pretaxIncome);
+        if (pbt == null && n(v.netIncome) != null && n(v.incomeTaxExpense) != null) pbt = v.netIncome + v.incomeTaxExpense;
+        const totalExpenses = totalIncome != null && pbt != null ? totalIncome - pbt : null;
+        const cor = n(v.costOfRevenue), fc = n(v.interestExpense);
+        const otherExp = totalExpenses != null ? totalExpenses - (add([cor, fc]) || 0) : null;
+        const totalTax = n(v.incomeTaxExpense), deferredTax = n(v.deferredIncomeTaxes);
+        const currentTax = totalTax != null ? totalTax - (deferredTax || 0) : null;
+        const pat = pbt != null && totalTax != null ? pbt - totalTax : null;
+        const netIncome = n(v.netIncome);
+        const otherItems = netIncome != null && pat != null ? netIncome - pat : null;
+
+        const L = (label, kind, level, value, unit) => ({ label, kind, level, value, unit: unit || 'USD' });
+        const lines = [
+          L('I. Revenue from operations', 'item', 1, revenue),
+          L('II. Other income', 'item', 1, otherIncome),
+          L('III. Total Income (I + II)', 'subtotal', 0, totalIncome),
+          L('IV. Expenses', 'header', 1, null),
+          L('Cost of revenue / materials & services', 'item', 2, cor),
+          L('Finance costs', 'item', 2, fc),
+          L('Other expenses (operating & unmapped)', 'item', 2, otherExp),
+          L('Total Expenses', 'subtotal', 1, totalExpenses),
+          L('V. Profit Before Tax (III − IV)', 'subtotal', 0, pbt),
+          L('VI. Tax expense', 'header', 1, null),
+          L('(1) Current tax', 'item', 2, currentTax),
+          L('(2) Deferred tax', 'item', 2, deferredTax),
+          L('Total tax expense', 'subtotal', 1, totalTax),
+          L('VII. Profit After Tax (V − VI)', 'subtotal', 0, pat),
+          L('VIII. Other items (NCI, discontinued ops)', 'item', 1, otherItems),
+          L('IX. Profit for the period', 'grandtotal', 0, netIncome),
+          L('X. Earnings per equity share', 'header', 1, null),
+          L('(1) Basic', 'item', 2, n(v.epsBasic), 'USD/shares'),
+          L('(2) Diluted', 'item', 2, n(v.dilutedEPS), 'USD/shares'),
+        ];
+        return { lines };
+      }
+      function renderScheduleTable(title, schedules, periods, yearHeads, legend) {
+        const lines = schedules[0].lines;
+        const body = lines.map((ln, idx) => {
+          const cls = { header: 'bs-header', subtotal: 'bs-subtotal', grandtotal: 'bs-grand', sub: 'bs-sub', item: 'bs-item' }[ln.kind] || '';
+          const pad = (0.5 + ln.level * 1.1).toFixed(2);
+          const cells = (ln.kind === 'header' && ln.value == null)
+            ? periods.map(() => '<td></td>').join('')
+            : schedules.map((s) => {
+                const c = s.lines[idx];
+                return `<td>${c.value == null ? '<span class="na">—</span>' : esc(fmtByUnit(c.unit || 'USD', c.value))}</td>`;
+              }).join('');
+          return `<tr class="${cls}"><td class="metric" style="padding-left:${pad}rem">${esc(ln.label)}</td>${cells}</tr>`;
+        }).join('');
+        return `<section class="group"><h2>${esc(title)}</h2><div class="scroll"><table>` +
+          `<thead><tr><th class="metric">Particulars</th>${yearHeads}</tr></thead><tbody>${body}</tbody></table></div>` +
+          (legend ? `<p class="legend">${legend}</p>` : '') + `</section>`;
+      }
+      function renderIncomeStatement(periods, yearHeads) {
+        if (!periods.length) return '';
+        return renderScheduleTable(
+          'Statement of Profit & Loss — Companies Act 2013, Schedule III',
+          periods.map(scheduleIIIPL), periods, yearHeads,
+          'US-GAAP (functional) expenses recast into Schedule III natural heads; "Other expenses" absorbs operating costs (R&D, sales & marketing, G&A) and embedded D&A so Total Income − Total Expenses = Profit Before Tax.'
+        );
+      }
+
       // ---- curated model rendering -----------------------------------------
       function render(data) {
         const periods = data.periods || [];
@@ -463,9 +535,9 @@
           periods.map((p) => `<td class="na">${esc(p.accessionNumber || '—')}</td>`).join('') + `</tr>` +
           `</tbody></table></div></section>`;
 
-        // Income statement and per-share render as flat tables; the balance
-        // sheet is recast into the Schedule III vertical format below.
-        const groupsHtml = ['inc', 'ps'].map((g) => {
+        // Income statement and balance sheet are recast into Schedule III
+        // vertical format; per-share renders as a flat table.
+        const groupsHtml = ['ps'].map((g) => {
           const fields = FIELD_DEFS.filter((f) => f[2] === g);
           const rows = fields.map(([key, label]) => {
             if (!periods.some((p) => p[key] !== null && p[key] !== undefined)) return '';
@@ -480,8 +552,8 @@
           .map((w) => `<div class="banner">⚠ ${esc(w)}</div>`)
           .join('');
         document.getElementById('sections').innerHTML =
-          warnHtml + filingsHtml + groupsHtml + renderBalanceSheet(periods, yearHeads) +
-          renderCashFlow(periods, yearHeads);
+          warnHtml + filingsHtml + renderIncomeStatement(periods, yearHeads) + groupsHtml +
+          renderBalanceSheet(periods, yearHeads) + renderCashFlow(periods, yearHeads);
         renderRatios(periods);
         initWacc(periods[0]);
         document.getElementById('raw').textContent = JSON.stringify(data, null, 2);

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SEC EDGAR 10-K Financials</title>
+    <style>
+      :root {
+        --bg: #0f172a;
+        --panel: #1e293b;
+        --line: #334155;
+        --text: #e2e8f0;
+        --muted: #94a3b8;
+        --accent: #38bdf8;
+        --error: #f87171;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        padding: 2rem 1rem;
+      }
+      .wrap { max-width: 1100px; margin: 0 auto; }
+      h1 { font-size: 1.4rem; margin: 0 0 0.25rem; }
+      p.sub { color: var(--muted); margin: 0 0 1.5rem; font-size: 0.9rem; }
+      form { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; margin-bottom: 1rem; }
+      input, button, select {
+        background: var(--panel);
+        color: var(--text);
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        padding: 0.55rem 0.75rem;
+        font-size: 0.95rem;
+      }
+      input { text-transform: uppercase; width: 130px; }
+      button { cursor: pointer; border-color: var(--accent); color: var(--accent); font-weight: 600; }
+      button:disabled { opacity: 0.5; cursor: not-allowed; }
+      .status { margin: 1rem 0; font-size: 0.95rem; }
+      .status.error { color: var(--error); }
+      .meta { color: var(--muted); font-size: 0.85rem; margin-bottom: 0.75rem; }
+      table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+      th, td { border: 1px solid var(--line); padding: 0.5rem 0.6rem; text-align: right; white-space: nowrap; }
+      th:first-child, td:first-child { text-align: left; position: sticky; left: 0; background: var(--panel); }
+      thead th { background: var(--panel); position: sticky; top: 0; }
+      .scroll { overflow-x: auto; border: 1px solid var(--line); border-radius: 8px; }
+      .tag { cursor: help; border-bottom: 1px dotted var(--muted); }
+      .row-label { color: var(--muted); cursor: pointer; }
+      details { margin-top: 1.5rem; }
+      summary { cursor: pointer; color: var(--accent); }
+      pre { background: var(--panel); padding: 1rem; border-radius: 8px; overflow: auto; font-size: 0.75rem; max-height: 360px; }
+      .audit td { color: var(--muted); font-size: 0.72rem; }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <h1>SEC EDGAR 10-K Financials</h1>
+      <p class="sub">
+        Structured annual financial data pulled from the official SEC EDGAR XBRL JSON APIs.
+        No PDF extraction, no API key. Hover a value to see the raw US-GAAP tag used.
+      </p>
+
+      <form id="form">
+        <input id="ticker" name="ticker" placeholder="NFLX" value="NFLX" autocomplete="off" />
+        <select id="years" name="years">
+          <option value="">All years</option>
+          <option value="3">Last 3</option>
+          <option value="5" selected>Last 5</option>
+          <option value="10">Last 10</option>
+        </select>
+        <button id="submit" type="submit">Fetch</button>
+      </form>
+
+      <div id="status" class="status"></div>
+      <div id="meta" class="meta"></div>
+      <div id="result" class="scroll" hidden>
+        <table id="table">
+          <thead>
+            <tr id="head"></tr>
+          </thead>
+          <tbody id="body"></tbody>
+        </table>
+      </div>
+
+      <details id="rawWrap" hidden>
+        <summary>Raw normalized JSON (with per-value audit trail)</summary>
+        <pre id="raw"></pre>
+      </details>
+    </div>
+
+    <script>
+      const ROWS = [
+        ['revenue', 'Revenue'],
+        ['costOfRevenue', 'Cost of Revenue'],
+        ['grossProfit', 'Gross Profit'],
+        ['operatingIncome', 'Operating Income'],
+        ['netIncome', 'Net Income'],
+        ['totalAssets', 'Total Assets'],
+        ['currentAssets', 'Current Assets'],
+        ['cashAndEquivalents', 'Cash & Equivalents'],
+        ['totalLiabilities', 'Total Liabilities'],
+        ['stockholdersEquity', "Stockholders' Equity"],
+        ['operatingCashFlow', 'Operating Cash Flow'],
+        ['capitalExpenditure', 'Capital Expenditure'],
+        ['dilutedEPS', 'Diluted EPS'],
+        ['dilutedShares', 'Diluted Shares'],
+      ];
+
+      const form = document.getElementById('form');
+      const statusEl = document.getElementById('status');
+      const metaEl = document.getElementById('meta');
+      const resultEl = document.getElementById('result');
+      const headEl = document.getElementById('head');
+      const bodyEl = document.getElementById('body');
+      const rawWrap = document.getElementById('rawWrap');
+      const rawEl = document.getElementById('raw');
+      const submitBtn = document.getElementById('submit');
+
+      function fmt(field, value) {
+        if (value === null || value === undefined) return '—';
+        if (field === 'dilutedEPS') return value.toFixed(2);
+        if (field === 'dilutedShares') return value.toLocaleString();
+        const abs = Math.abs(value);
+        if (abs >= 1e9) return (value / 1e9).toFixed(2) + 'B';
+        if (abs >= 1e6) return (value / 1e6).toFixed(2) + 'M';
+        return value.toLocaleString();
+      }
+
+      function render(data) {
+        metaEl.textContent =
+          `${data.companyName} — CIK ${data.cik} — ${data.periods.length} annual 10-K period(s)`;
+
+        headEl.innerHTML = '<th>Metric</th>' +
+          data.periods.map((p) => `<th>FY${p.fiscalYear}</th>`).join('');
+
+        bodyEl.innerHTML = ROWS.map(([field, label]) => {
+          const cells = data.periods.map((p) => {
+            const audit = p.rawTagsUsed[field];
+            const title = audit
+              ? `tag: ${audit.tag}\nunit: ${audit.unit}\nfiled: ${audit.filed}\naccession: ${audit.accessionNumber}\nform: ${audit.form}`
+              : 'no data';
+            const cls = audit ? 'tag' : '';
+            return `<td><span class="${cls}" title="${title.replace(/"/g, '&quot;')}">${fmt(field, p[field])}</span></td>`;
+          });
+          return `<tr><td class="row-label">${label}</td>${cells.join('')}</tr>`;
+        }).join('');
+
+        const filedRow =
+          '<tr class="audit"><td>Filed</td>' +
+          data.periods.map((p) => `<td>${p.filed || '—'}</td>`).join('') +
+          '</tr>';
+        bodyEl.insertAdjacentHTML('beforeend', filedRow);
+
+        resultEl.hidden = false;
+        rawEl.textContent = JSON.stringify(data, null, 2);
+        rawWrap.hidden = false;
+      }
+
+      async function run(ticker, years) {
+        statusEl.className = 'status';
+        statusEl.textContent = 'Loading…';
+        resultEl.hidden = true;
+        rawWrap.hidden = true;
+        metaEl.textContent = '';
+        submitBtn.disabled = true;
+        try {
+          const params = new URLSearchParams({ ticker });
+          if (years) params.set('years', years);
+          const res = await fetch(`/api/sec/model-data?${params.toString()}`);
+          const data = await res.json();
+          if (!res.ok) throw new Error(data.error || `Request failed (${res.status})`);
+          if (!data.periods.length) {
+            statusEl.textContent = 'No annual 10-K data found for this ticker.';
+            return;
+          }
+          statusEl.textContent = '';
+          render(data);
+        } catch (err) {
+          statusEl.className = 'status error';
+          statusEl.textContent = `Error: ${err.message}`;
+        } finally {
+          submitBtn.disabled = false;
+        }
+      }
+
+      form.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const ticker = document.getElementById('ticker').value.trim();
+        const years = document.getElementById('years').value;
+        if (ticker) run(ticker, years);
+      });
+    </script>
+  </body>
+</html>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -125,7 +125,7 @@
         </div>
         <div class="field">
           <label for="api">Backend URL</label>
-          <input id="api" placeholder="http://localhost:3000" />
+          <input id="api" placeholder="http://localhost:5050" />
         </div>
         <div class="field">
           <label>&nbsp;</label>
@@ -283,7 +283,7 @@
 
       function defaultApiBase() {
         if (location.protocol === 'http:' || location.protocol === 'https:') return location.origin;
-        return 'http://localhost:3000';
+        return 'http://localhost:5050';
       }
 
       async function fetchLive() {

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -6,31 +6,19 @@
     <title>SEC EDGAR 10-K Financials</title>
     <style>
       :root {
-        --bg: #0b1120;
-        --panel: #111c33;
-        --panel2: #16243f;
-        --line: #2b3b5b;
-        --text: #e6edf6;
-        --muted: #8aa0c0;
-        --accent: #4cc4ff;
-        --good: #4ade80;
-        --bad: #f87171;
-        --warn: #fbbf24;
+        --bg: #0b1120; --panel: #111c33; --panel2: #16243f; --line: #2b3b5b;
+        --text: #e6edf6; --muted: #8aa0c0; --accent: #4cc4ff; --good: #4ade80;
+        --bad: #f87171; --warn: #fbbf24;
       }
       * { box-sizing: border-box; }
       body {
-        margin: 0;
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
         background: radial-gradient(1200px 600px at 80% -10%, #15233f 0%, var(--bg) 55%);
-        color: var(--text);
-        min-height: 100vh;
-        padding: 2rem 1rem 4rem;
+        color: var(--text); min-height: 100vh; padding: 2rem 1rem 4rem;
       }
-      .wrap { max-width: 1180px; margin: 0 auto; }
-      header.app { margin-bottom: 1.25rem; }
+      .wrap { max-width: 1240px; margin: 0 auto; }
       h1 { font-size: 1.5rem; margin: 0 0 0.25rem; }
-      p.sub { color: var(--muted); margin: 0; font-size: 0.9rem; max-width: 760px; }
-
+      p.sub { color: var(--muted); margin: 0; font-size: 0.9rem; max-width: 780px; }
       .controls {
         display: flex; gap: 0.6rem; flex-wrap: wrap; align-items: flex-end;
         background: var(--panel); border: 1px solid var(--line); border-radius: 12px;
@@ -48,7 +36,6 @@
       button.primary { background: var(--accent); color: #04243a; border-color: var(--accent); }
       button.ghost { color: var(--accent); }
       button:disabled { opacity: 0.5; cursor: not-allowed; }
-
       .status { margin: 0.5rem 0 1rem; font-size: 0.95rem; min-height: 1.2rem; }
       .status.error { color: var(--bad); }
       .status.loading { color: var(--accent); }
@@ -56,41 +43,31 @@
         background: rgba(251, 191, 36, 0.12); border: 1px solid var(--warn); color: var(--warn);
         padding: 0.55rem 0.8rem; border-radius: 8px; font-size: 0.82rem; margin-bottom: 1rem;
       }
-
       .company {
         display: flex; flex-wrap: wrap; gap: 1.5rem; align-items: baseline;
         border-bottom: 1px solid var(--line); padding-bottom: 0.9rem; margin-bottom: 1.25rem;
       }
       .company .name { font-size: 1.35rem; font-weight: 800; }
-      .company .pill {
-        font-size: 0.72rem; color: var(--muted);
-        border: 1px solid var(--line); border-radius: 999px; padding: 0.15rem 0.6rem;
-      }
-
+      .company .pill { font-size: 0.72rem; color: var(--muted); border: 1px solid var(--line); border-radius: 999px; padding: 0.15rem 0.6rem; }
       section.group { margin-bottom: 1.6rem; }
-      section.group > h2 {
-        font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.08em;
-        color: var(--accent); margin: 0 0 0.5rem;
-      }
+      section.group > h2 { font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--accent); margin: 0 0 0.5rem; }
       .scroll { overflow-x: auto; border: 1px solid var(--line); border-radius: 10px; }
       table { width: 100%; border-collapse: collapse; font-size: 0.86rem; }
-      th, td { padding: 0.55rem 0.7rem; text-align: right; white-space: nowrap; border-bottom: 1px solid var(--line); }
+      th, td { padding: 0.5rem 0.7rem; text-align: right; white-space: nowrap; border-bottom: 1px solid var(--line); }
       thead th { background: var(--panel); color: var(--muted); font-weight: 600; position: sticky; top: 0; }
       tbody tr:hover { background: rgba(76, 196, 255, 0.06); }
-      th.metric, td.metric {
-        text-align: left; position: sticky; left: 0; background: var(--panel);
-        font-weight: 600; min-width: 190px;
-      }
+      th.metric, td.metric { text-align: left; position: sticky; left: 0; background: var(--panel); font-weight: 600; min-width: 210px; }
+      th.tag, td.tagcol { text-align: left; min-width: 230px; }
       tbody tr:hover td.metric { background: var(--panel2); }
       td .val { font-variant-numeric: tabular-nums; }
-      td .tag {
-        display: block; font-size: 0.68rem; color: var(--muted); margin-top: 0.1rem;
-        cursor: help; border-bottom: 1px dotted transparent;
-      }
+      td .tag { display: block; font-size: 0.68rem; color: var(--muted); margin-top: 0.1rem; cursor: help; border-bottom: 1px dotted transparent; }
       td .tag:hover { border-bottom-color: var(--muted); }
       td.derived .val::after { content: " ∗"; color: var(--warn); }
       .na { color: #56688a; }
-
+      .allctrl { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; margin-bottom: 0.6rem; }
+      .allctrl input { width: 280px; }
+      .allctrl .count { color: var(--muted); font-size: 0.82rem; }
+      code.tagname { color: var(--accent); font-size: 0.8rem; }
       details.raw { margin-top: 1.5rem; }
       details.raw summary { cursor: pointer; color: var(--accent); font-weight: 600; }
       pre { background: var(--panel); border: 1px solid var(--line); padding: 1rem; border-radius: 10px; overflow: auto; font-size: 0.74rem; max-height: 420px; }
@@ -103,9 +80,10 @@
       <header class="app">
         <h1>SEC EDGAR · 10-K Financials</h1>
         <p class="sub">
-          Structured annual financial-statement data pulled from the official SEC EDGAR
-          XBRL JSON APIs — no API key, no PDF extraction. Every figure links back to the
-          exact US-GAAP tag it came from (shown beneath each value).
+          Structured annual financial-statement data from the official SEC EDGAR XBRL JSON APIs —
+          no API key, no PDF extraction. A curated full three-statement model, plus an
+          "all reported facts" explorer for everything the company tagged. Each value links back to
+          its exact US-GAAP tag.
         </p>
       </header>
 
@@ -129,7 +107,7 @@
         </div>
         <div class="field">
           <label>&nbsp;</label>
-          <button id="fetchBtn" class="primary" type="button">Fetch live data</button>
+          <button id="fetchBtn" class="primary" type="button">Load live data</button>
         </div>
         <div class="field">
           <label>&nbsp;</label>
@@ -144,11 +122,27 @@
         <div class="company" id="company"></div>
         <div id="sections"></div>
 
+        <section class="group" id="allFactsSection">
+          <h2>All reported facts — everything SEC has</h2>
+          <div class="allctrl">
+            <button id="allFactsBtn" class="ghost" type="button">Load all reported facts</button>
+            <input id="allSearch" placeholder="Filter by tag or label…" disabled />
+            <span class="count" id="allCount"></span>
+          </div>
+          <div id="allScroll" class="scroll hidden">
+            <table>
+              <thead><tr id="allHead"></tr></thead>
+              <tbody id="allBody"></tbody>
+            </table>
+          </div>
+          <p class="legend" id="allNote"></p>
+        </section>
+
         <p class="legend">
-          Hover the tag under any value to see its unit, filing accession number and filed date.
+          Hover the tag under any value to see its unit, accession number and filed date.
           <strong>∗</strong> marks a derived value (e.g. total liabilities computed from current +
-          non-current). <span class="na">—</span> means the company did not report that tag for
-          the period.
+          non-current). <span class="na">—</span> means the company did not report that tag for the
+          period. Empty rows are hidden automatically.
         </p>
 
         <details class="raw">
@@ -159,42 +153,76 @@
     </div>
 
     <script>
-      // ---- field groups / formatting ---------------------------------------
-      const GROUPS = [
-        { title: 'Income Statement', fields: [
-          ['revenue', 'Revenue', 'money'],
-          ['costOfRevenue', 'Cost of Revenue', 'money'],
-          ['grossProfit', 'Gross Profit', 'money'],
-          ['operatingIncome', 'Operating Income', 'money'],
-          ['netIncome', 'Net Income', 'money'],
-        ]},
-        { title: 'Balance Sheet', fields: [
-          ['totalAssets', 'Total Assets', 'money'],
-          ['currentAssets', 'Current Assets', 'money'],
-          ['cashAndEquivalents', 'Cash & Equivalents', 'money'],
-          ['totalLiabilities', 'Total Liabilities', 'money'],
-          ['stockholdersEquity', "Stockholders' Equity", 'money'],
-        ]},
-        { title: 'Cash Flow', fields: [
-          ['operatingCashFlow', 'Operating Cash Flow', 'money'],
-          ['capitalExpenditure', 'Capital Expenditure', 'money'],
-        ]},
-        { title: 'Per Share', fields: [
-          ['dilutedEPS', 'Diluted EPS', 'eps'],
-          ['dilutedShares', 'Diluted Shares', 'shares'],
-        ]},
+      // ---- curated field metadata (mirrors server/src/tagMap.js) -----------
+      // [key, label, group, unit]   group: inc | ps | bs | cf
+      const FIELD_DEFS = [
+        ['revenue', 'Revenue', 'inc', 'USD'],
+        ['costOfRevenue', 'Cost of Revenue', 'inc', 'USD'],
+        ['grossProfit', 'Gross Profit', 'inc', 'USD'],
+        ['researchAndDevelopment', 'R&D Expense', 'inc', 'USD'],
+        ['sellingAndMarketing', 'Selling & Marketing', 'inc', 'USD'],
+        ['generalAndAdministrative', 'General & Administrative', 'inc', 'USD'],
+        ['sellingGeneralAndAdministrative', 'SG&A (combined)', 'inc', 'USD'],
+        ['totalOperatingExpenses', 'Total Operating Expenses', 'inc', 'USD'],
+        ['operatingIncome', 'Operating Income', 'inc', 'USD'],
+        ['interestExpense', 'Interest Expense', 'inc', 'USD'],
+        ['interestIncome', 'Interest / Investment Income', 'inc', 'USD'],
+        ['otherIncomeExpense', 'Other Non-Operating Income', 'inc', 'USD'],
+        ['pretaxIncome', 'Pre-Tax Income', 'inc', 'USD'],
+        ['incomeTaxExpense', 'Income Tax Expense', 'inc', 'USD'],
+        ['netIncome', 'Net Income', 'inc', 'USD'],
+        ['epsBasic', 'EPS (Basic)', 'ps', 'USD/shares'],
+        ['dilutedEPS', 'EPS (Diluted)', 'ps', 'USD/shares'],
+        ['sharesBasic', 'Shares (Basic)', 'ps', 'shares'],
+        ['dilutedShares', 'Shares (Diluted)', 'ps', 'shares'],
+        ['dividendsPerShare', 'Dividends per Share', 'ps', 'USD/shares'],
+        ['cashAndEquivalents', 'Cash & Equivalents', 'bs', 'USD'],
+        ['shortTermInvestments', 'Short-Term Investments', 'bs', 'USD'],
+        ['accountsReceivable', 'Accounts Receivable', 'bs', 'USD'],
+        ['inventory', 'Inventory', 'bs', 'USD'],
+        ['otherCurrentAssets', 'Other Current Assets', 'bs', 'USD'],
+        ['currentAssets', 'Total Current Assets', 'bs', 'USD'],
+        ['propertyPlantEquipmentNet', 'PP&E, Net', 'bs', 'USD'],
+        ['goodwill', 'Goodwill', 'bs', 'USD'],
+        ['intangibleAssets', 'Intangible Assets', 'bs', 'USD'],
+        ['totalAssets', 'Total Assets', 'bs', 'USD'],
+        ['accountsPayable', 'Accounts Payable', 'bs', 'USD'],
+        ['shortTermDebt', 'Short-Term / Current Debt', 'bs', 'USD'],
+        ['deferredRevenueCurrent', 'Deferred Revenue (Current)', 'bs', 'USD'],
+        ['currentLiabilities', 'Total Current Liabilities', 'bs', 'USD'],
+        ['longTermDebt', 'Long-Term Debt', 'bs', 'USD'],
+        ['totalLiabilities', 'Total Liabilities', 'bs', 'USD'],
+        ['commonStockValue', 'Common Stock', 'bs', 'USD'],
+        ['additionalPaidInCapital', 'Additional Paid-In Capital', 'bs', 'USD'],
+        ['retainedEarnings', 'Retained Earnings', 'bs', 'USD'],
+        ['treasuryStock', 'Treasury Stock', 'bs', 'USD'],
+        ['accumulatedOCI', 'Accumulated OCI', 'bs', 'USD'],
+        ['stockholdersEquity', "Stockholders' Equity", 'bs', 'USD'],
+        ['depreciationAmortization', 'Depreciation & Amortization', 'cf', 'USD'],
+        ['stockBasedCompensation', 'Stock-Based Compensation', 'cf', 'USD'],
+        ['operatingCashFlow', 'Operating Cash Flow', 'cf', 'USD'],
+        ['capitalExpenditure', 'Capital Expenditure', 'cf', 'USD'],
+        ['acquisitions', 'Acquisitions, Net', 'cf', 'USD'],
+        ['investingCashFlow', 'Investing Cash Flow', 'cf', 'USD'],
+        ['debtIssued', 'Debt Issued', 'cf', 'USD'],
+        ['debtRepaid', 'Debt Repaid', 'cf', 'USD'],
+        ['stockRepurchased', 'Stock Repurchased', 'cf', 'USD'],
+        ['dividendsPaid', 'Dividends Paid', 'cf', 'USD'],
+        ['financingCashFlow', 'Financing Cash Flow', 'cf', 'USD'],
       ];
+      const GROUP_TITLES = { inc: 'Income Statement', ps: 'Per Share', bs: 'Balance Sheet', cf: 'Cash Flow' };
+      const GROUP_ORDER = ['inc', 'ps', 'bs', 'cf'];
+      const ALL_KEYS = FIELD_DEFS.map((f) => f[0]);
 
-      function fmt(kind, v) {
+      function fmtByUnit(unit, v) {
         if (v === null || v === undefined) return null;
-        if (kind === 'eps') return '$' + Number(v).toFixed(2);
-        if (kind === 'shares') {
+        if (unit === 'USD/shares') return '$' + Number(v).toFixed(2);
+        if (unit === 'shares') {
           const a = Math.abs(v);
           if (a >= 1e9) return (v / 1e9).toFixed(2) + 'B';
           if (a >= 1e6) return (v / 1e6).toFixed(1) + 'M';
           return Number(v).toLocaleString();
         }
-        // money
         const sign = v < 0 ? '-' : '';
         const a = Math.abs(v);
         if (a >= 1e9) return sign + '$' + (a / 1e9).toFixed(2) + 'B';
@@ -202,11 +230,10 @@
         if (a >= 1e3) return sign + '$' + (a / 1e3).toFixed(0) + 'K';
         return sign + '$' + a;
       }
-
       const esc = (s) =>
         String(s).replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
 
-      // ---- rendering --------------------------------------------------------
+      // ---- curated model rendering -----------------------------------------
       function render(data) {
         const periods = data.periods || [];
         document.getElementById('company').innerHTML = [
@@ -217,52 +244,112 @@
         ].join('');
 
         const yearHeads = periods.map((p) => `<th>FY ${p.fiscalYear}</th>`).join('');
-        const filedRow =
-          `<tr><td class="metric">Filed</td>` +
-          periods.map((p) => `<td class="na">${esc(p.filed || '—')}</td>`).join('') +
-          `</tr>`;
 
-        const sectionsHtml = GROUPS.map((g) => {
-          const rows = g.fields.map(([field, label, kind]) => {
+        const filingsHtml =
+          `<section class="group"><h2>Filings</h2><div class="scroll"><table>` +
+          `<thead><tr><th class="metric">Metric</th>${yearHeads}</tr></thead><tbody>` +
+          `<tr><td class="metric">Filed</td>` +
+          periods.map((p) => `<td class="na">${esc(p.filed || '—')}</td>`).join('') + `</tr>` +
+          `<tr><td class="metric">Accession #</td>` +
+          periods.map((p) => `<td class="na">${esc(p.accessionNumber || '—')}</td>`).join('') + `</tr>` +
+          `</tbody></table></div></section>`;
+
+        const groupsHtml = GROUP_ORDER.map((g) => {
+          const fields = FIELD_DEFS.filter((f) => f[2] === g);
+          const rows = fields.map(([key, label, , unit]) => {
+            const hasAny = periods.some((p) => p[key] !== null && p[key] !== undefined);
+            if (!hasAny) return ''; // hide empty rows
             const cells = periods.map((p) => {
-              const raw = p[field];
-              const audit = p.rawTagsUsed ? p.rawTagsUsed[field] : null;
-              const text = fmt(kind, raw);
+              const raw = p[key];
+              const audit = p.rawTagsUsed ? p.rawTagsUsed[key] : null;
+              const text = fmtByUnit(unit, raw);
               if (text === null) return `<td><span class="val na">—</span></td>`;
               const derived = audit && audit.derived ? ' derived' : '';
               const tip = audit
                 ? `tag: ${audit.tag}\nunit: ${audit.unit}\nfiscal year: ${audit.fiscalYear}\nfiled: ${audit.filed}\naccession: ${audit.accessionNumber}\nform: ${audit.form}\nexact value: ${raw}`
                 : `exact value: ${raw}`;
-              const tagLabel = audit ? esc(audit.tag) : '';
-              return (
-                `<td class="${derived}">` +
-                `<span class="val">${esc(text)}</span>` +
-                (tagLabel ? `<span class="tag" title="${esc(tip)}">${tagLabel}</span>` : '') +
-                `</td>`
-              );
+              return `<td class="${derived}"><span class="val">${esc(text)}</span>` +
+                (audit ? `<span class="tag" title="${esc(tip)}">${esc(audit.tag)}</span>` : '') + `</td>`;
             }).join('');
             return `<tr><td class="metric">${esc(label)}</td>${cells}</tr>`;
           }).join('');
-
-          return (
-            `<section class="group"><h2>${esc(g.title)}</h2><div class="scroll"><table>` +
-            `<thead><tr><th class="metric">Metric</th>${yearHeads}</tr></thead>` +
-            `<tbody>${rows}</tbody></table></div></section>`
-          );
+          if (!rows) return '';
+          return `<section class="group"><h2>${esc(GROUP_TITLES[g])}</h2><div class="scroll"><table>` +
+            `<thead><tr><th class="metric">Metric</th>${yearHeads}</tr></thead><tbody>${rows}</tbody></table></div></section>`;
         }).join('');
 
-        // Filings overview table on top.
-        const filingsHtml =
-          `<section class="group"><h2>Filings</h2><div class="scroll"><table>` +
-          `<thead><tr><th class="metric">Metric</th>${yearHeads}</tr></thead>` +
-          `<tbody>${filedRow}` +
-          `<tr><td class="metric">Accession #</td>` +
-          periods.map((p) => `<td class="na">${esc(p.accessionNumber || '—')}</td>`).join('') +
-          `</tr></tbody></table></div></section>`;
-
-        document.getElementById('sections').innerHTML = filingsHtml + sectionsHtml;
+        document.getElementById('sections').innerHTML = filingsHtml + groupsHtml;
         document.getElementById('raw').textContent = JSON.stringify(data, null, 2);
         document.getElementById('result').classList.remove('hidden');
+        resetAllFacts();
+      }
+
+      // ---- all reported facts ----------------------------------------------
+      let allFactsData = null;
+      function resetAllFacts() {
+        allFactsData = null;
+        document.getElementById('allScroll').classList.add('hidden');
+        document.getElementById('allCount').textContent = '';
+        document.getElementById('allNote').textContent = '';
+        const search = document.getElementById('allSearch');
+        search.value = '';
+        search.disabled = true;
+        document.getElementById('allFactsBtn').disabled = false;
+      }
+
+      function renderAllFacts(filter) {
+        if (!allFactsData) return;
+        const years = allFactsData.fiscalYears;
+        document.getElementById('allHead').innerHTML =
+          `<th class="tag">US-GAAP Tag</th>` + years.map((y) => `<th>FY ${y}</th>`).join('');
+        const f = (filter || '').trim().toLowerCase();
+        const concepts = f
+          ? allFactsData.concepts.filter(
+              (c) => c.tag.toLowerCase().includes(f) || (c.label || '').toLowerCase().includes(f)
+            )
+          : allFactsData.concepts;
+        document.getElementById('allBody').innerHTML = concepts.map((c) => {
+          const cells = years.map((y) => {
+            const cell = c.values[y];
+            if (!cell) return `<td><span class="na">—</span></td>`;
+            const tip = `unit: ${cell.unit}\nfiled: ${cell.filed}\naccession: ${cell.accessionNumber}\nperiod end: ${cell.periodEnd}\nexact value: ${cell.value}`;
+            return `<td title="${esc(tip)}">${esc(fmtByUnit(c.unit, cell.value))}</td>`;
+          }).join('');
+          return `<tr><td class="tagcol"><code class="tagname">${esc(c.tag)}</code>` +
+            (c.label && c.label !== c.tag ? `<span class="tag">${esc(c.label)}</span>` : '') +
+            `</td>${cells}</tr>`;
+        }).join('');
+        document.getElementById('allCount').textContent =
+          concepts.length + ' / ' + allFactsData.concepts.length + ' concepts';
+        document.getElementById('allScroll').classList.remove('hidden');
+      }
+
+      async function loadAllFacts() {
+        if (isDemo) {
+          document.getElementById('allNote').textContent =
+            'All-facts is a live-only feature (it returns hundreds of concepts straight from SEC). Click "Load live data" against a running backend to use it.';
+          return;
+        }
+        const ticker = currentTicker;
+        const years = document.getElementById('years').value;
+        const base = apiBase();
+        const btn = document.getElementById('allFactsBtn');
+        btn.disabled = true;
+        document.getElementById('allNote').textContent = 'Loading every reported concept…';
+        try {
+          const params = new URLSearchParams({ ticker });
+          if (years) params.set('years', years);
+          const res = await fetch(base + '/api/sec/all-facts?' + params.toString());
+          const data = await res.json();
+          if (!res.ok) throw new Error(data.error || ('Request failed (' + res.status + ')'));
+          allFactsData = data;
+          document.getElementById('allNote').textContent = '';
+          document.getElementById('allSearch').disabled = false;
+          renderAllFacts('');
+        } catch (err) {
+          document.getElementById('allNote').textContent = 'Error: ' + err.message;
+          btn.disabled = false;
+        }
       }
 
       // ---- data sources -----------------------------------------------------
@@ -270,28 +357,19 @@
       const bannerEl = document.getElementById('banner');
       const fetchBtn = document.getElementById('fetchBtn');
       const demoBtn = document.getElementById('demoBtn');
+      let isDemo = true;
+      let currentTicker = 'NFLX';
 
-      function setStatus(msg, kind) {
-        statusEl.className = 'status' + (kind ? ' ' + kind : '');
-        statusEl.textContent = msg || '';
-      }
-      function showBanner(msg) {
-        if (!msg) { bannerEl.classList.add('hidden'); return; }
-        bannerEl.textContent = msg;
-        bannerEl.classList.remove('hidden');
-      }
-
-      function defaultApiBase() {
-        if (location.protocol === 'http:' || location.protocol === 'https:') return location.origin;
-        return 'http://localhost:5050';
-      }
+      const setStatus = (msg, kind) => { statusEl.className = 'status' + (kind ? ' ' + kind : ''); statusEl.textContent = msg || ''; };
+      const showBanner = (msg) => { if (!msg) { bannerEl.classList.add('hidden'); return; } bannerEl.textContent = msg; bannerEl.classList.remove('hidden'); };
+      const defaultApiBase = () => (location.protocol === 'http:' || location.protocol === 'https:') ? location.origin : 'http://localhost:5050';
+      const apiBase = () => (document.getElementById('api').value.trim() || defaultApiBase()).replace(/\/$/, '');
 
       async function fetchLive() {
         const ticker = document.getElementById('ticker').value.trim().toUpperCase();
         const years = document.getElementById('years').value;
-        const base = (document.getElementById('api').value.trim() || defaultApiBase()).replace(/\/$/, '');
+        const base = apiBase();
         if (!ticker) { setStatus('Enter a ticker first.', 'error'); return; }
-
         showBanner('');
         setStatus('Loading ' + ticker + ' from ' + base + ' …', 'loading');
         document.getElementById('result').classList.add('hidden');
@@ -302,10 +380,9 @@
           const res = await fetch(base + '/api/sec/model-data?' + params.toString());
           const data = await res.json();
           if (!res.ok) throw new Error(data.error || ('Request failed (' + res.status + ')'));
-          if (!data.periods || !data.periods.length) {
-            setStatus('No annual 10-K data found for ' + ticker + '.', 'error');
-            return;
-          }
+          if (!data.periods || !data.periods.length) { setStatus('No annual 10-K data found for ' + ticker + '.', 'error'); return; }
+          isDemo = false;
+          currentTicker = ticker;
           setStatus('Loaded ' + ticker + ' — live SEC data.');
           render(data);
         } catch (err) {
@@ -316,82 +393,83 @@
       }
 
       function loadDemo() {
-        showBanner('Sample data shown for layout preview — approximate Netflix figures, not a live SEC pull. Click "Fetch live data" against a running backend for real numbers.');
+        isDemo = true;
+        showBanner('Sample data shown for layout preview — approximate Netflix figures, not a live SEC pull. Click "Load live data" against a running backend for real numbers (and the full all-facts explorer).');
         setStatus('');
         render(buildDemo());
       }
 
-      // ---- bundled sample dataset (normalized output shape) -----------------
+      // ---- bundled sample dataset ------------------------------------------
       function buildDemo() {
-        const FIELD_TAG = {
-          revenue: 'Revenues',
-          costOfRevenue: 'CostOfGoodsAndServicesSold',
-          grossProfit: 'GrossProfit',
-          operatingIncome: 'OperatingIncomeLoss',
-          netIncome: 'NetIncomeLoss',
-          totalAssets: 'Assets',
-          currentAssets: 'AssetsCurrent',
-          cashAndEquivalents: 'CashAndCashEquivalentsAtCarryingValue',
-          totalLiabilities: 'Liabilities',
-          stockholdersEquity: 'StockholdersEquity',
-          operatingCashFlow: 'NetCashProvidedByUsedInOperatingActivities',
-          capitalExpenditure: 'PaymentsToAcquirePropertyPlantAndEquipment',
-          dilutedEPS: 'EarningsPerShareDiluted',
-          dilutedShares: 'WeightedAverageNumberOfDilutedSharesOutstanding',
+        const TAG = {
+          revenue: 'Revenues', costOfRevenue: 'CostOfGoodsAndServicesSold', grossProfit: 'GrossProfit',
+          researchAndDevelopment: 'ResearchAndDevelopmentExpense', sellingAndMarketing: 'SellingAndMarketingExpense',
+          generalAndAdministrative: 'GeneralAndAdministrativeExpense', totalOperatingExpenses: 'OperatingExpenses',
+          operatingIncome: 'OperatingIncomeLoss', interestExpense: 'InterestExpense', interestIncome: 'InvestmentIncomeInterest',
+          otherIncomeExpense: 'NonoperatingIncomeExpense', pretaxIncome: 'IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest',
+          incomeTaxExpense: 'IncomeTaxExpenseBenefit', netIncome: 'NetIncomeLoss', epsBasic: 'EarningsPerShareBasic',
+          dilutedEPS: 'EarningsPerShareDiluted', sharesBasic: 'WeightedAverageNumberOfSharesOutstandingBasic',
+          dilutedShares: 'WeightedAverageNumberOfDilutedSharesOutstanding', cashAndEquivalents: 'CashAndCashEquivalentsAtCarryingValue',
+          shortTermInvestments: 'ShortTermInvestments', currentAssets: 'AssetsCurrent', propertyPlantEquipmentNet: 'PropertyPlantAndEquipmentNet',
+          goodwill: 'Goodwill', totalAssets: 'Assets', accountsPayable: 'AccountsPayableCurrent', shortTermDebt: 'LongTermDebtCurrent',
+          deferredRevenueCurrent: 'ContractWithCustomerLiabilityCurrent', currentLiabilities: 'LiabilitiesCurrent',
+          longTermDebt: 'LongTermDebtNoncurrent', totalLiabilities: 'Liabilities', additionalPaidInCapital: 'AdditionalPaidInCapital',
+          retainedEarnings: 'RetainedEarningsAccumulatedDeficit', accumulatedOCI: 'AccumulatedOtherComprehensiveIncomeLossNetOfTax',
+          stockholdersEquity: 'StockholdersEquity', depreciationAmortization: 'DepreciationDepletionAndAmortization',
+          stockBasedCompensation: 'ShareBasedCompensation', operatingCashFlow: 'NetCashProvidedByUsedInOperatingActivities',
+          capitalExpenditure: 'PaymentsToAcquirePropertyPlantAndEquipment', investingCashFlow: 'NetCashProvidedByUsedInInvestingActivities',
+          debtIssued: 'ProceedsFromIssuanceOfLongTermDebt', debtRepaid: 'RepaymentsOfLongTermDebt',
+          stockRepurchased: 'PaymentsForRepurchaseOfCommonStock', financingCashFlow: 'NetCashProvidedByUsedInFinancingActivities',
         };
-        const UNIT = { dilutedEPS: 'USD/shares', dilutedShares: 'shares' };
-        const ALL = Object.keys(FIELD_TAG);
-
+        const UNIT = (k) => (FIELD_DEFS.find((f) => f[0] === k) || [])[3] || 'USD';
         const RAW = [
           { fy: 2024, filed: '2025-01-27', accn: '0001065280-25-000044', v: {
-            revenue: 39000966000, costOfRevenue: 21038000000, grossProfit: 17962966000,
-            operatingIncome: 10417874000, netIncome: 8711631000, totalAssets: 53629000000,
-            currentAssets: 9792000000, cashAndEquivalents: 7804000000, totalLiabilities: 28886000000,
-            stockholdersEquity: 24743000000, operatingCashFlow: 6921000000, capitalExpenditure: 439000000,
-            dilutedEPS: 19.83, dilutedShares: 439380000 } },
+            revenue: 39000966000, costOfRevenue: 21038000000, grossProfit: 17962966000, researchAndDevelopment: 2925000000,
+            sellingAndMarketing: 2554000000, generalAndAdministrative: 1700000000, totalOperatingExpenses: 28583092000,
+            operatingIncome: 10417874000, interestExpense: 718733000, interestIncome: 690000000, otherIncomeExpense: -266000000,
+            pretaxIncome: 10124000000, incomeTaxExpense: 1254000000, netIncome: 8711631000, epsBasic: 20.27, dilutedEPS: 19.83,
+            sharesBasic: 429700000, dilutedShares: 439380000, cashAndEquivalents: 7804000000, shortTermInvestments: 432000000,
+            currentAssets: 9792000000, propertyPlantEquipmentNet: 1631000000, goodwill: 284000000, totalAssets: 53629000000,
+            accountsPayable: 747000000, shortTermDebt: 1784000000, deferredRevenueCurrent: 1442000000, currentLiabilities: 9621000000,
+            longTermDebt: 13682000000, totalLiabilities: 28886000000, additionalPaidInCapital: 5184000000, retainedEarnings: 22790000000,
+            accumulatedOCI: -300000000, stockholdersEquity: 24743000000, depreciationAmortization: 14400000000, stockBasedCompensation: 575000000,
+            operatingCashFlow: 6921000000, capitalExpenditure: 439000000, investingCashFlow: -325000000, debtIssued: 1797000000,
+            debtRepaid: 1809000000, stockRepurchased: 6072000000, financingCashFlow: -3722000000 } },
           { fy: 2023, filed: '2024-01-26', accn: '0001065280-24-000029', v: {
-            revenue: 33723297000, costOfRevenue: 19715368000, grossProfit: 14007929000,
-            operatingIncome: 6954303000, netIncome: 5407990000, totalAssets: 48731992000,
-            currentAssets: 9918133000, cashAndEquivalents: 7116913000, totalLiabilities: 28107976000,
-            stockholdersEquity: 20624016000, operatingCashFlow: 7273885000, capitalExpenditure: 348428000,
-            dilutedEPS: 12.03, dilutedShares: 449498000 } },
+            revenue: 33723297000, costOfRevenue: 19715368000, grossProfit: 14007929000, researchAndDevelopment: 2675000000,
+            sellingAndMarketing: 2657000000, generalAndAdministrative: 1492000000, totalOperatingExpenses: 26769000000,
+            operatingIncome: 6954303000, interestExpense: 699826000, interestIncome: 460000000, otherIncomeExpense: -48000000,
+            pretaxIncome: 6206000000, incomeTaxExpense: 797000000, netIncome: 5407990000, epsBasic: 12.21, dilutedEPS: 12.03,
+            sharesBasic: 442800000, dilutedShares: 449498000, cashAndEquivalents: 7116913000, shortTermInvestments: 1390000000,
+            currentAssets: 9918133000, propertyPlantEquipmentNet: 1491000000, goodwill: 284000000, totalAssets: 48731992000,
+            accountsPayable: 747412000, shortTermDebt: 399844000, deferredRevenueCurrent: 1442969000, currentLiabilities: 8860655000,
+            longTermDebt: 14143417000, totalLiabilities: 28107976000, additionalPaidInCapital: 4905000000, retainedEarnings: 17489000000,
+            accumulatedOCI: -350000000, stockholdersEquity: 20624016000, depreciationAmortization: 14296000000, stockBasedCompensation: 432000000,
+            operatingCashFlow: 7273885000, capitalExpenditure: 348428000, investingCashFlow: -252000000, debtIssued: 0,
+            debtRepaid: 1198000000, stockRepurchased: 6043000000, financingCashFlow: -8480000000 } },
           { fy: 2022, filed: '2023-01-27', accn: '0001065280-23-000017', v: {
-            revenue: 31615550000, costOfRevenue: 19168285000, grossProfit: 12447265000,
-            operatingIncome: 5632831000, netIncome: 4491924000, totalAssets: 48594768000,
-            currentAssets: null, cashAndEquivalents: 5147176000, totalLiabilities: null,
-            stockholdersEquity: 20777401000, operatingCashFlow: 2021131000, capitalExpenditure: 407719000,
-            dilutedEPS: 9.95, dilutedShares: 451290000 } },
+            revenue: 31615550000, costOfRevenue: 19168285000, grossProfit: 12447265000, operatingIncome: 5632831000,
+            netIncome: 4491924000, dilutedEPS: 9.95, dilutedShares: 451290000, cashAndEquivalents: 5147176000,
+            totalAssets: 48594768000, stockholdersEquity: 20777401000, operatingCashFlow: 2021131000, capitalExpenditure: 407719000 } },
           { fy: 2021, filed: '2022-01-28', accn: '0001065280-22-000036', v: {
-            revenue: 29697844000, costOfRevenue: null, grossProfit: null,
-            operatingIncome: 6194509000, netIncome: 5116228000, totalAssets: null,
-            currentAssets: null, cashAndEquivalents: 6027804000, totalLiabilities: null,
-            stockholdersEquity: 15849248000, operatingCashFlow: 392610000, capitalExpenditure: 524585000,
-            dilutedEPS: 11.24, dilutedShares: 455372000 } },
+            revenue: 29697844000, operatingIncome: 6194509000, netIncome: 5116228000, dilutedEPS: 11.24, dilutedShares: 455372000,
+            cashAndEquivalents: 6027804000, stockholdersEquity: 15849248000, operatingCashFlow: 392610000, capitalExpenditure: 524585000 } },
         ];
-
         const periods = RAW.map((p) => {
           const period = { fiscalYear: p.fy, form: '10-K', filed: p.filed, accessionNumber: p.accn };
           const rawTagsUsed = {};
-          for (const field of ALL) {
-            const val = p.v[field];
-            period[field] = val === undefined ? null : val;
-            if (val === null || val === undefined) continue;
-            rawTagsUsed[field] = {
-              tag: FIELD_TAG[field],
-              unit: UNIT[field] || 'USD',
-              value: val,
-              fiscalYear: p.fy,
-              reportFiscalYear: p.fy,
-              accessionNumber: p.accn,
-              filed: p.filed,
-              form: '10-K',
-              periodEnd: p.fy + '-12-31',
+          for (const key of ALL_KEYS) {
+            const val = p.v[key];
+            period[key] = val === undefined ? null : val;
+            if (val === undefined || val === null) continue;
+            rawTagsUsed[key] = {
+              tag: TAG[key] || key, unit: UNIT(key), value: val, fiscalYear: p.fy, reportFiscalYear: p.fy,
+              accessionNumber: p.accn, filed: p.filed, form: '10-K', periodEnd: p.fy + '-12-31',
             };
           }
           period.rawTagsUsed = rawTagsUsed;
           return period;
         });
-
         return { ticker: 'NFLX', cik: '0001065280', companyName: 'NETFLIX INC', periods };
       }
 
@@ -399,12 +477,11 @@
       document.getElementById('api').value = defaultApiBase();
       fetchBtn.addEventListener('click', fetchLive);
       demoBtn.addEventListener('click', loadDemo);
-      document.getElementById('ticker').addEventListener('keydown', (e) => {
-        if (e.key === 'Enter') fetchLive();
-      });
+      document.getElementById('allFactsBtn').addEventListener('click', loadAllFacts);
+      document.getElementById('allSearch').addEventListener('input', (e) => renderAllFacts(e.target.value));
+      document.getElementById('ticker').addEventListener('keydown', (e) => { if (e.key === 'Enter') fetchLive(); });
 
-      // Show the sample table immediately so the formatting is visible on load.
-      loadDemo();
+      loadDemo(); // show the formatted sample immediately on load
     </script>
   </body>
 </html>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -71,6 +71,22 @@
       .allctrl input { width: 280px; }
       .allctrl .count { color: var(--muted); font-size: 0.82rem; }
       code.tagname { color: var(--accent); font-size: 0.8rem; }
+      .card { background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 1rem 1.1rem; margin-bottom: 1.4rem; }
+      .card h3 { margin: 0 0 0.6rem; font-size: 0.95rem; }
+      .facts { display: flex; flex-wrap: wrap; gap: 0.4rem 1.4rem; font-size: 0.85rem; margin-bottom: 0.6rem; }
+      .facts .f { color: var(--muted); }
+      .facts .f b { color: var(--text); font-weight: 600; }
+      .narrative { font-size: 0.88rem; line-height: 1.55; color: var(--text); margin: 0.4rem 0 0.9rem; max-width: 900px; }
+      .snap, .wacc-out { display: flex; flex-wrap: wrap; gap: 0.7rem; }
+      .kpi { background: var(--panel2); border: 1px solid var(--line); border-radius: 8px; padding: 0.45rem 0.8rem; min-width: 118px; }
+      .kpi .label { font-size: 0.66rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; }
+      .kpi .num { font-size: 1.05rem; font-weight: 700; font-variant-numeric: tabular-nums; }
+      .kpi.big { border-color: var(--accent); }
+      .kpi .num.big { font-size: 1.5rem; color: var(--accent); }
+      .num.pos { color: var(--good); } .num.neg { color: var(--bad); }
+      .wacc-inputs { display: flex; flex-wrap: wrap; gap: 0.8rem; align-items: flex-end; margin-bottom: 0.9rem; }
+      .wacc-inputs .field input { width: 130px; }
+      .muted { color: var(--muted); font-size: 0.8rem; margin: 0.6rem 0 0; max-width: 900px; }
       details.raw { margin-top: 1.5rem; }
       details.raw summary { cursor: pointer; color: var(--accent); font-weight: 600; }
       pre { background: var(--panel); border: 1px solid var(--line); padding: 1rem; border-radius: 10px; overflow: auto; font-size: 0.74rem; max-height: 420px; }
@@ -127,7 +143,10 @@
 
       <div id="result" class="hidden">
         <div class="company" id="company"></div>
+        <div id="profile"></div>
         <div id="sections"></div>
+        <div id="ratiosSection"></div>
+        <div id="waccSection"></div>
 
         <section class="group" id="allFactsSection">
           <h2>All reported facts — everything SEC has</h2>
@@ -287,6 +306,8 @@
         }).join('');
 
         document.getElementById('sections').innerHTML = filingsHtml + groupsHtml;
+        renderRatios(periods);
+        initWacc(periods[0]);
         document.getElementById('raw').textContent = JSON.stringify(data, null, 2);
         document.getElementById('result').classList.remove('hidden');
         lastData = data;
@@ -396,6 +417,7 @@
           currentTicker = ticker;
           setStatus('Loaded ' + ticker + ' — live SEC data.');
           render(data);
+          fetchProfile(base, ticker, data.periods);
         } catch (err) {
           setStatus('Error: ' + err.message + ' — is the backend running at ' + base + '?', 'error');
         } finally {
@@ -407,7 +429,9 @@
         isDemo = true;
         showBanner('Sample data shown for layout preview — approximate Netflix figures, not a live SEC pull. Click "Load live data" against a running backend for real numbers (and the full all-facts explorer).');
         setStatus('');
-        render(buildDemo());
+        const d = buildDemo();
+        render(d);
+        renderProfile(DEMO_PROFILE, d.periods);
       }
 
       // ---- bundled sample dataset ------------------------------------------
@@ -482,6 +506,230 @@
           return period;
         });
         return { ticker: 'NFLX', cik: '0001065280', companyName: 'NETFLIX INC', periods };
+      }
+
+      // ---- profile ----------------------------------------------------------
+      const DEMO_PROFILE = {
+        industry: 'Streaming Entertainment (SIC 7841)', exchanges: ['NASDAQ'],
+        stateOfIncorporation: 'DE', fiscalYearEnd: '1231',
+        headquarters: { city: 'Los Gatos', state: 'CA' },
+        narrative: 'Sample profile — Netflix is a subscription streaming entertainment service. Figures shown are approximate and for layout preview only; load live data for the real profile.',
+      };
+      const moneyStr = (v) => (v == null ? '—' : fmtByUnit('USD', v));
+      const pctStr = (v, dp = 1) => (v == null ? '—' : (v * 100).toFixed(dp) + '%');
+      const kpi = (label, num, cls = '') => `<div class="kpi ${cls}"><div class="label">${esc(label)}</div><div class="num ${cls}">${num}</div></div>`;
+
+      function snapshotClient(periods) {
+        if (!periods || !periods.length) return null;
+        const L = periods[0], P = periods[1] || null;
+        const div = (a, b) => (a == null || b == null || b === 0 ? null : a / b);
+        return {
+          fiscalYear: L.fiscalYear, revenue: L.revenue,
+          revenueGrowth: P ? div((L.revenue || 0) - (P.revenue || 0), P.revenue) : null,
+          grossMargin: div(L.grossProfit, L.revenue), operatingMargin: div(L.operatingIncome, L.revenue),
+          netMargin: div(L.netIncome, L.revenue), returnOnEquity: div(L.netIncome, L.stockholdersEquity),
+        };
+      }
+      function renderProfile(meta, periods) {
+        const s = snapshotClient(periods);
+        const f = (l, v) => (v ? `<span class="f">${esc(l)}: <b>${esc(v)}</b></span>` : '');
+        const facts = [
+          f('Industry', meta.industry),
+          f('Exchange', (meta.exchanges || []).join(', ')),
+          meta.headquarters ? f('HQ', [meta.headquarters.city, meta.headquarters.state].filter(Boolean).join(', ')) : '',
+          f('Incorporated', meta.stateOfIncorporation),
+          f('Fiscal year end', meta.fiscalYearEnd),
+        ].join('');
+        let snap = '';
+        if (s) {
+          const g = s.revenueGrowth == null ? '' :
+            `<div class="num ${s.revenueGrowth >= 0 ? 'pos' : 'neg'}" style="font-size:0.8rem">${(s.revenueGrowth * 100).toFixed(1)}% YoY</div>`;
+          snap = `<div class="snap">` +
+            `<div class="kpi"><div class="label">Revenue FY${s.fiscalYear}</div><div class="num">${moneyStr(s.revenue)}</div>${g}</div>` +
+            kpi('Gross margin', pctStr(s.grossMargin)) +
+            kpi('Operating margin', pctStr(s.operatingMargin)) +
+            kpi('Net margin', pctStr(s.netMargin)) +
+            kpi('Return on equity', pctStr(s.returnOnEquity)) +
+            `</div>`;
+        }
+        document.getElementById('profile').innerHTML =
+          `<div class="card"><h3>Company profile</h3>` +
+          `<div class="facts">${facts}</div>` +
+          (meta.narrative ? `<p class="narrative">${esc(meta.narrative)}</p>` : '') + snap + `</div>`;
+      }
+      async function fetchProfile(base, ticker, periods) {
+        try {
+          const res = await fetch(base + '/api/sec/profile?ticker=' + encodeURIComponent(ticker));
+          const data = await res.json();
+          if (!res.ok) throw new Error('profile');
+          renderProfile({
+            industry: data.industry, exchanges: data.exchanges, stateOfIncorporation: data.stateOfIncorporation,
+            fiscalYearEnd: data.fiscalYearEnd, headquarters: data.headquarters, narrative: data.narrative,
+          }, periods);
+        } catch (_) {
+          document.getElementById('profile').innerHTML = '';
+        }
+      }
+
+      // ---- ratios -----------------------------------------------------------
+      const RATIO_ROWS = [
+        ['currentRatio', 'Current Ratio', 'x'],
+        ['quickRatio', 'Quick Ratio', 'x'],
+        ['workingCapital', 'Working Capital', 'money'],
+        ['daysSalesOutstanding', 'Days Sales Outstanding (DSO)', 'days'],
+        ['daysPayablesOutstanding', 'Days Payables Outstanding (DPO)', 'days'],
+        ['daysInventoryOutstanding', 'Days Inventory Outstanding (DIO)', 'days'],
+        ['cashConversionCycle', 'Cash Conversion Cycle', 'days'],
+        ['debtToEquity', 'Debt / Equity', 'x'],
+        ['debtToAssets', 'Debt / Assets', 'x'],
+        ['interestCoverage', 'Interest Coverage', 'x'],
+        ['netMargin', 'Net Margin', 'pct'],
+        ['returnOnEquity', 'Return on Equity', 'pct'],
+        ['returnOnAssets', 'Return on Assets', 'pct'],
+      ];
+      function fmtRatio(type, v) {
+        if (v == null) return null;
+        if (type === 'pct') return (v * 100).toFixed(1) + '%';
+        if (type === 'days') return v.toFixed(0) + 'd';
+        if (type === 'money') return fmtByUnit('USD', v);
+        return v.toFixed(2) + '×';
+      }
+      function computeRatiosClient(periods) {
+        const div = (a, b) => (a == null || b == null || b === 0 ? null : a / b);
+        const days = (bal, flow) => (bal == null || flow == null || flow === 0 ? null : (bal / Math.abs(flow)) * 365);
+        return (periods || []).map((p) => {
+          const totalDebt = (p.shortTermDebt || 0) + (p.longTermDebt || 0) || null;
+          const dso = days(p.accountsReceivable, p.revenue);
+          const dpo = days(p.accountsPayable, p.costOfRevenue);
+          const dio = days(p.inventory, p.costOfRevenue);
+          const ccc = dso == null && dpo == null && dio == null ? null : (dso || 0) + (dio || 0) - (dpo || 0);
+          return {
+            fiscalYear: p.fiscalYear,
+            currentRatio: div(p.currentAssets, p.currentLiabilities),
+            quickRatio: div(p.currentAssets != null ? p.currentAssets - (p.inventory || 0) : null, p.currentLiabilities),
+            workingCapital: p.currentAssets != null && p.currentLiabilities != null ? p.currentAssets - p.currentLiabilities : null,
+            daysSalesOutstanding: dso, daysPayablesOutstanding: dpo, daysInventoryOutstanding: dio, cashConversionCycle: ccc,
+            debtToEquity: div(totalDebt, p.stockholdersEquity), debtToAssets: div(totalDebt, p.totalAssets),
+            interestCoverage: div(p.operatingIncome, p.interestExpense),
+            netMargin: div(p.netIncome, p.revenue), returnOnEquity: div(p.netIncome, p.stockholdersEquity), returnOnAssets: div(p.netIncome, p.totalAssets),
+          };
+        });
+      }
+      function renderRatios(periods) {
+        const rows = computeRatiosClient(periods);
+        const yearHeads = periods.map((p) => `<th>FY ${p.fiscalYear}</th>`).join('');
+        const body = RATIO_ROWS.map(([key, label, type]) => {
+          if (!rows.some((r) => r[key] != null)) return '';
+          const cells = rows.map((r) => {
+            const t = fmtRatio(type, r[key]);
+            return `<td>${t == null ? '<span class="na">—</span>' : esc(t)}</td>`;
+          }).join('');
+          return `<tr><td class="metric">${esc(label)}</td>${cells}</tr>`;
+        }).join('');
+        document.getElementById('ratiosSection').innerHTML = body
+          ? `<section class="group"><h2>Ratios &amp; Working Capital</h2><div class="scroll"><table>` +
+            `<thead><tr><th class="metric">Ratio</th>${yearHeads}</tr></thead><tbody>${body}</tbody></table></div></section>`
+          : '';
+      }
+
+      // ---- WACC -------------------------------------------------------------
+      let waccPeriod = null;
+      const waccState = { beta: null, marketCap: null, rf: '4.3', erp: '5.5' };
+
+      function computeWaccClient(period, inp) {
+        const n = (v) => (typeof v === 'number' && isFinite(v) ? v : null);
+        const totalDebt = (period.shortTermDebt || 0) + (period.longTermDebt || 0) || null;
+        const interest = n(period.interestExpense);
+        const costOfDebt = interest != null && totalDebt ? interest / totalDebt : null;
+        let taxRate = null;
+        if (n(period.incomeTaxExpense) != null && n(period.pretaxIncome) && period.pretaxIncome !== 0) {
+          taxRate = Math.min(Math.max(period.incomeTaxExpense / period.pretaxIncome, 0), 0.5);
+        }
+        const rf = n(inp.rf), beta = n(inp.beta), erp = n(inp.erp), E = n(inp.marketCap);
+        const costOfEquity = rf != null && beta != null && erp != null ? rf + beta * erp : null;
+        const afterTaxCoD = costOfDebt != null && taxRate != null ? costOfDebt * (1 - taxRate) : null;
+        let we = null, wd = null, wacc = null;
+        if (E != null && totalDebt != null && E + totalDebt > 0) {
+          const V = E + totalDebt; we = E / V; wd = totalDebt / V;
+          if (costOfEquity != null && afterTaxCoD != null) wacc = we * costOfEquity + wd * afterTaxCoD;
+        }
+        return { totalDebt, interest, costOfDebt, taxRate, costOfEquity, afterTaxCoD, we, wd, wacc };
+      }
+      const waccField = (id, label, val, ph) =>
+        `<div class="field"><label for="${id}">${esc(label)}</label>` +
+        `<input id="${id}" value="${val === '' || val == null ? '' : esc(val)}" placeholder="${esc(ph)}" inputmode="decimal" /></div>`;
+
+      function initWacc(period) {
+        if (!period) { document.getElementById('waccSection').innerHTML = ''; return; }
+        waccPeriod = period;
+        document.getElementById('waccSection').innerHTML =
+          `<section class="group"><h2>WACC — Cost of Capital (FY${period.fiscalYear})</h2><div class="card">` +
+          `<div class="wacc-inputs">` +
+            waccField('wBeta', 'Beta (β)', waccState.beta, 'e.g. 1.25') +
+            waccField('wRf', 'Risk-free %', waccState.rf, '4.3') +
+            waccField('wErp', 'Equity risk premium %', waccState.erp, '5.5') +
+            waccField('wMc', 'Market cap ($)', waccState.marketCap, 'e.g. 350000000000') +
+            `<div class="field"><label>&nbsp;</label><button id="waccFetch" class="ghost" type="button">Fetch β & market cap</button></div>` +
+          `</div><div id="waccOut" class="wacc-out"></div><p class="muted" id="waccNote"></p></div></section>`;
+        ['wBeta', 'wRf', 'wErp', 'wMc'].forEach((id) =>
+          document.getElementById(id).addEventListener('input', recomputeWacc));
+        document.getElementById('waccFetch').addEventListener('click', fetchWaccInputs);
+        recomputeWacc();
+      }
+      function recomputeWacc() {
+        if (!waccPeriod) return;
+        const beta = parseFloat(document.getElementById('wBeta').value);
+        const rfPct = document.getElementById('wRf').value, erpPct = document.getElementById('wErp').value;
+        const mc = parseFloat(document.getElementById('wMc').value);
+        waccState.beta = isFinite(beta) ? beta : null;
+        waccState.marketCap = isFinite(mc) ? mc : null;
+        waccState.rf = rfPct; waccState.erp = erpPct;
+        const r = computeWaccClient(waccPeriod, {
+          beta: isFinite(beta) ? beta : null,
+          rf: isFinite(parseFloat(rfPct)) ? parseFloat(rfPct) / 100 : null,
+          erp: isFinite(parseFloat(erpPct)) ? parseFloat(erpPct) / 100 : null,
+          marketCap: isFinite(mc) ? mc : null,
+        });
+        const p2 = (v) => (v == null ? '—' : (v * 100).toFixed(2) + '%');
+        document.getElementById('waccOut').innerHTML = [
+          kpi('WACC', p2(r.wacc), 'big'),
+          kpi('Cost of equity', p2(r.costOfEquity)),
+          kpi('Cost of debt (pre-tax)', p2(r.costOfDebt)),
+          kpi('After-tax cost of debt', p2(r.afterTaxCoD)),
+          kpi('Tax rate', pctStr(r.taxRate)),
+          kpi('Equity weight', pctStr(r.we)),
+          kpi('Debt weight', pctStr(r.wd)),
+          kpi('Total debt (book)', moneyStr(r.totalDebt)),
+        ].join('');
+        const notes = ['Cost of debt, tax rate and book debt are SEC-derived; β and market cap come from the market-data provider or your input; risk-free defaults to the US Treasury 10-yr (override above).'];
+        if (r.costOfDebt == null) notes.push('This company did not report interest expense and/or debt, so pre-tax cost of debt is blank — enter it manually if known.');
+        document.getElementById('waccNote').textContent = notes.join(' ');
+      }
+      async function fetchWaccInputs() {
+        if (isDemo) {
+          document.getElementById('waccNote').textContent =
+            'Auto-fetch needs a running backend with a market-data API key. In sample mode, enter β and market cap manually.';
+          return;
+        }
+        const btn = document.getElementById('waccFetch');
+        btn.disabled = true;
+        try {
+          const res = await fetch(apiBase() + '/api/sec/wacc?ticker=' + encodeURIComponent(currentTicker));
+          const data = await res.json();
+          if (!res.ok) throw new Error(data.error || ('Request failed (' + res.status + ')'));
+          if (data.inputs.beta != null) document.getElementById('wBeta').value = data.inputs.beta;
+          if (data.inputs.marketValueOfEquity != null) document.getElementById('wMc').value = data.inputs.marketValueOfEquity;
+          if (data.inputs.riskFreeRate != null) document.getElementById('wRf').value = (data.inputs.riskFreeRate * 100).toFixed(2);
+          recomputeWacc();
+          if (!data.meta.marketDataConfigured) {
+            document.getElementById('waccNote').textContent =
+              'Backend has no market-data API key (ALPHAVANTAGE_API_KEY), so β and market cap came back empty — enter them manually or set a key and retry.';
+          }
+        } catch (err) {
+          document.getElementById('waccNote').textContent = 'Fetch error: ' + err.message;
+        } finally {
+          btn.disabled = false;
+        }
       }
 
       // ---- wiring -----------------------------------------------------------

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -49,20 +49,23 @@
       }
       .company .name { font-size: 1.35rem; font-weight: 800; }
       .company .pill { font-size: 0.72rem; color: var(--muted); border: 1px solid var(--line); border-radius: 999px; padding: 0.15rem 0.6rem; }
-      section.group { margin-bottom: 1.6rem; }
-      section.group > h2 { font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--accent); margin: 0 0 0.5rem; }
+      .chk { display: flex; align-items: center; gap: 0.4rem; font-size: 0.85rem; color: var(--text); padding: 0.55rem 0; cursor: pointer; }
+      .chk input { width: auto; }
+      section.group { margin-bottom: 1.1rem; }
+      section.group > h2 { font-size: 0.74rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--accent); margin: 0 0 0.35rem; }
       .scroll { overflow-x: auto; border: 1px solid var(--line); border-radius: 10px; }
-      table { width: 100%; border-collapse: collapse; font-size: 0.86rem; }
-      th, td { padding: 0.5rem 0.7rem; text-align: right; white-space: nowrap; border-bottom: 1px solid var(--line); }
-      thead th { background: var(--panel); color: var(--muted); font-weight: 600; position: sticky; top: 0; }
-      tbody tr:hover { background: rgba(76, 196, 255, 0.06); }
-      th.metric, td.metric { text-align: left; position: sticky; left: 0; background: var(--panel); font-weight: 600; min-width: 210px; }
+      table { width: 100%; border-collapse: collapse; font-size: 0.82rem; }
+      th, td { padding: 0.34rem 0.7rem; text-align: right; white-space: nowrap; }
+      thead th { background: var(--panel); color: var(--muted); font-weight: 600; position: sticky; top: 0; border-bottom: 1px solid var(--line); }
+      tbody tr:nth-child(even) { background: rgba(255, 255, 255, 0.018); }
+      tbody tr:hover { background: rgba(76, 196, 255, 0.08); }
+      th.metric, td.metric { text-align: left; position: sticky; left: 0; background: var(--panel); font-weight: 500; min-width: 175px; }
+      tbody tr:nth-child(even) td.metric { background: #131f37; }
       th.tag, td.tagcol { text-align: left; min-width: 230px; }
       tbody tr:hover td.metric { background: var(--panel2); }
       td .val { font-variant-numeric: tabular-nums; }
-      td .tag { display: block; font-size: 0.68rem; color: var(--muted); margin-top: 0.1rem; cursor: help; border-bottom: 1px dotted transparent; }
-      td .tag:hover { border-bottom-color: var(--muted); }
       td.derived .val::after { content: " ∗"; color: var(--warn); }
+      td .tag, td.tagcol .tag { display: block; font-size: 0.68rem; color: var(--muted); margin-top: 0.05rem; }
       .na { color: #56688a; }
       .allctrl { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; margin-bottom: 0.6rem; }
       .allctrl input { width: 280px; }
@@ -113,6 +116,10 @@
           <label>&nbsp;</label>
           <button id="demoBtn" class="ghost" type="button">Load sample data</button>
         </div>
+        <div class="field">
+          <label>&nbsp;</label>
+          <label class="chk"><input type="checkbox" id="showTags" /> Show source tags</label>
+        </div>
       </div>
 
       <div id="status" class="status"></div>
@@ -139,7 +146,8 @@
         </section>
 
         <p class="legend">
-          Hover the tag under any value to see its unit, accession number and filed date.
+          Hover any value to see its source US-GAAP tag, unit, accession number and filed date — or
+          tick <em>Show source tags</em> above to display them inline.
           <strong>∗</strong> marks a derived value (e.g. total liabilities computed from current +
           non-current). <span class="na">—</span> means the company did not report that tag for the
           period. Empty rows are hidden automatically.
@@ -268,8 +276,8 @@
               const tip = audit
                 ? `tag: ${audit.tag}\nunit: ${audit.unit}\nfiscal year: ${audit.fiscalYear}\nfiled: ${audit.filed}\naccession: ${audit.accessionNumber}\nform: ${audit.form}\nexact value: ${raw}`
                 : `exact value: ${raw}`;
-              return `<td class="${derived}"><span class="val">${esc(text)}</span>` +
-                (audit ? `<span class="tag" title="${esc(tip)}">${esc(audit.tag)}</span>` : '') + `</td>`;
+              return `<td class="${derived}" title="${esc(tip)}"><span class="val">${esc(text)}</span>` +
+                (showTags && audit ? `<span class="tag">${esc(audit.tag)}</span>` : '') + `</td>`;
             }).join('');
             return `<tr><td class="metric">${esc(label)}</td>${cells}</tr>`;
           }).join('');
@@ -281,6 +289,7 @@
         document.getElementById('sections').innerHTML = filingsHtml + groupsHtml;
         document.getElementById('raw').textContent = JSON.stringify(data, null, 2);
         document.getElementById('result').classList.remove('hidden');
+        lastData = data;
         resetAllFacts();
       }
 
@@ -359,6 +368,8 @@
       const demoBtn = document.getElementById('demoBtn');
       let isDemo = true;
       let currentTicker = 'NFLX';
+      let showTags = false;
+      let lastData = null;
 
       const setStatus = (msg, kind) => { statusEl.className = 'status' + (kind ? ' ' + kind : ''); statusEl.textContent = msg || ''; };
       const showBanner = (msg) => { if (!msg) { bannerEl.classList.add('hidden'); return; } bannerEl.textContent = msg; bannerEl.classList.remove('hidden'); };
@@ -479,6 +490,10 @@
       demoBtn.addEventListener('click', loadDemo);
       document.getElementById('allFactsBtn').addEventListener('click', loadAllFacts);
       document.getElementById('allSearch').addEventListener('input', (e) => renderAllFacts(e.target.value));
+      document.getElementById('showTags').addEventListener('change', (e) => {
+        showTags = e.target.checked;
+        if (lastData) render(lastData);
+      });
       document.getElementById('ticker').addEventListener('keydown', (e) => { if (e.key === 'Enter') fetchLive(); });
 
       loadDemo(); // show the formatted sample immediately on load

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -276,6 +276,7 @@
         }
         const sign = v < 0 ? '-' : '';
         const a = Math.abs(v);
+        if (a >= 1e12) return sign + '$' + (a / 1e12).toFixed(2) + 'T';
         if (a >= 1e9) return sign + '$' + (a / 1e9).toFixed(2) + 'B';
         if (a >= 1e6) return sign + '$' + (a / 1e6).toFixed(1) + 'M';
         if (a >= 1e3) return sign + '$' + (a / 1e3).toFixed(0) + 'K';
@@ -802,6 +803,7 @@
           kpi('Tax rate', pctStr(r.taxRate)),
           kpi('Equity weight', pctStr(r.we)),
           kpi('Debt weight', pctStr(r.wd)),
+          kpi('Equity (market cap)', moneyStr(isFinite(mc) ? mc : null)),
           kpi('Total debt (book)', moneyStr(r.totalDebt)),
         ].join('');
         const notes = ['Cost of debt, tax rate and book debt are SEC-derived; β and market cap come from the market-data provider or your input; risk-free defaults to the US Treasury 10-yr (override above).'];
@@ -832,9 +834,10 @@
             const tax = b.taxRateUsed != null ? (b.taxRateUsed * 100).toFixed(0) + '%' : 'n/a';
             note += `β = ${b.industry} industry asset β ${b.unleveredBeta} re-levered to ${rel} (D/E ${de} ${b.deRatioBasis || ''}, tax ${tax}; ${b.vintage}). `;
           }
-          note += data.meta.marketDataConfigured
-            ? `Market cap from ${data.meta.marketDataSource}.`
-            : 'Market cap unavailable (no ALPHAVANTAGE_API_KEY) — enter it manually for the equity weight.';
+          const mc = data.inputs.marketValueOfEquity;
+          note += mc != null
+            ? `Market cap (equity) = ${fmtByUnit('USD', mc)} via ${data.meta.marketCapSource || 'provided'}. Market value of equity is normally far larger than book equity.`
+            : 'Market cap unavailable — enter it manually for the equity weight.';
           document.getElementById('waccNote').textContent = note;
         } catch (err) {
           document.getElementById('waccNote').textContent = 'Fetch error: ' + err.message;

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -890,7 +890,19 @@
         }).join('');
         const src = data.sourceDocument && data.sourceDocument.startsWith('http')
           ? ` · <a href="${esc(data.sourceDocument)}" target="_blank" rel="noopener" style="color:var(--accent)">source 10-K</a>` : '';
-        note.innerHTML = `Parsed from the latest 10-K inline XBRL (${esc(data.accessionNumber || '')})${src}. Only single-axis full-year breakdowns are shown; product×geography intersection cells are excluded to avoid double-counting.`;
+        let diag = '';
+        if (data.diagnostics) {
+          const ax = data.diagnostics.axesSeen
+            .map((a) => `<li><code class="tagname">${esc(a.axis)}</code>: ${a.members.map(esc).join(', ')}</li>`).join('');
+          const combos = data.diagnostics.axisCombinations
+            .map((c) => `<li>${esc(c.axes)} — ${c.count} fact(s)</li>`).join('');
+          diag = `<details style="margin-top:0.6rem"><summary style="cursor:pointer;color:var(--accent)">Diagnostics — all axes & combinations seen (${data.diagnostics.totalRevenueFacts} dimensional revenue facts)</summary>` +
+            `<div class="muted"><strong>Axes &amp; members:</strong><ul>${ax || '<li>none</li>'}</ul>` +
+            `<strong>Axis combinations:</strong><ul>${combos || '<li>none</li>'}</ul></div></details>`;
+        }
+        document.getElementById('segTables').insertAdjacentHTML('beforeend', diag);
+        const merged = data.filingsParsed ? `Merged ${data.filingsParsed} 10-K filing(s). ` : '';
+        note.innerHTML = `${merged}Latest filing ${esc(data.accessionNumber || '')}${src}. Only single-axis full-year breakdowns are tabled; multi-axis cells appear in diagnostics.`;
         document.getElementById('segCount').textContent = data.axes.length + ' breakdown(s)';
       }
       async function loadSegments() {

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -65,6 +65,8 @@
       tbody tr:hover td.metric { background: var(--panel2); }
       td .val { font-variant-numeric: tabular-nums; }
       td.derived .val::after { content: " ∗"; color: var(--warn); }
+      tr.cf-sub td { font-weight: 700; border-top: 1px solid var(--line); background: rgba(76, 196, 255, 0.05); }
+      tr.cf-sub td.metric { background: #16243f; }
       td .tag, td.tagcol .tag { display: block; font-size: 0.68rem; color: var(--muted); margin-top: 0.05rem; }
       .na { color: #56688a; }
       .allctrl { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; margin-bottom: 0.6rem; }
@@ -282,6 +284,57 @@
       const esc = (s) =>
         String(s).replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
 
+      const FIELD_BY_KEY = Object.fromEntries(FIELD_DEFS.map((f) => [f[0], f]));
+
+      function cellHtml(p, key) {
+        const def = FIELD_BY_KEY[key];
+        const unit = def ? def[3] : 'USD';
+        const raw = p[key];
+        const audit = p.rawTagsUsed ? p.rawTagsUsed[key] : null;
+        const text = fmtByUnit(unit, raw);
+        if (text === null) return `<td><span class="val na">—</span></td>`;
+        const derived = audit && audit.derived ? ' derived' : '';
+        const tip = audit
+          ? `tag: ${audit.tag}\nunit: ${audit.unit}\nfiscal year: ${audit.fiscalYear}\nfiled: ${audit.filed}\naccession: ${audit.accessionNumber}\nform: ${audit.form}\nexact value: ${raw}`
+          : `exact value: ${raw}`;
+        return `<td class="${derived}" title="${esc(tip)}"><span class="val">${esc(text)}</span>` +
+          (showTags && audit ? `<span class="tag">${esc(audit.tag)}</span>` : '') + `</td>`;
+      }
+
+      // Cash flow grouped into the three AS 3 / IAS 7 activities (indirect method).
+      const CF_GROUPS = [
+        { title: 'Cash Flow — Operating Activities (Indirect)',
+          lead: [['netIncome', 'Net income (starting point)']],
+          rows: [['depreciationAmortization'], ['amortizationOfIntangibles'], ['stockBasedCompensation'],
+            ['deferredIncomeTaxes'], ['otherNoncashItems'], ['changeInWorkingCapital'],
+            ['operatingCashFlow', 'Net cash from operating activities', true]] },
+        { title: 'Cash Flow — Investing Activities',
+          rows: [['capitalExpenditure'], ['acquisitions'], ['investingCashFlow', 'Net cash from investing activities', true]] },
+        { title: 'Cash Flow — Financing Activities',
+          rows: [['debtIssued'], ['debtRepaid'], ['stockRepurchased'], ['stockIssued'], ['dividendsPaid'],
+            ['financingCashFlow', 'Net cash from financing activities', true]] },
+        { title: 'Cash Flow — Reconciliation',
+          rows: [['effectOfExchangeRate'], ['netChangeInCash', 'Net change in cash', true]] },
+      ];
+      function renderCashFlow(periods, yearHeads) {
+        return CF_GROUPS.map((g) => {
+          const out = [];
+          (g.lead || []).forEach(([key, label]) => {
+            if (periods.some((p) => p[key] != null)) {
+              out.push(`<tr><td class="metric">${esc(label)}</td>${periods.map((p) => cellHtml(p, key)).join('')}</tr>`);
+            }
+          });
+          g.rows.forEach(([key, label, sub]) => {
+            if (!sub && !periods.some((p) => p[key] != null)) return;
+            const lbl = label || (FIELD_BY_KEY[key] ? FIELD_BY_KEY[key][1] : key);
+            out.push(`<tr class="${sub ? 'cf-sub' : ''}"><td class="metric">${esc(lbl)}</td>${periods.map((p) => cellHtml(p, key)).join('')}</tr>`);
+          });
+          if (!out.length) return '';
+          return `<section class="group"><h2>${esc(g.title)}</h2><div class="scroll"><table>` +
+            `<thead><tr><th class="metric">Line item</th>${yearHeads}</tr></thead><tbody>${out.join('')}</tbody></table></div></section>`;
+        }).join('');
+      }
+
       // ---- curated model rendering -----------------------------------------
       function render(data) {
         const periods = data.periods || [];
@@ -303,24 +356,12 @@
           periods.map((p) => `<td class="na">${esc(p.accessionNumber || '—')}</td>`).join('') + `</tr>` +
           `</tbody></table></div></section>`;
 
-        const groupsHtml = GROUP_ORDER.map((g) => {
+        // Income statement, per-share and balance sheet render as flat tables.
+        const groupsHtml = ['inc', 'ps', 'bs'].map((g) => {
           const fields = FIELD_DEFS.filter((f) => f[2] === g);
-          const rows = fields.map(([key, label, , unit]) => {
-            const hasAny = periods.some((p) => p[key] !== null && p[key] !== undefined);
-            if (!hasAny) return ''; // hide empty rows
-            const cells = periods.map((p) => {
-              const raw = p[key];
-              const audit = p.rawTagsUsed ? p.rawTagsUsed[key] : null;
-              const text = fmtByUnit(unit, raw);
-              if (text === null) return `<td><span class="val na">—</span></td>`;
-              const derived = audit && audit.derived ? ' derived' : '';
-              const tip = audit
-                ? `tag: ${audit.tag}\nunit: ${audit.unit}\nfiscal year: ${audit.fiscalYear}\nfiled: ${audit.filed}\naccession: ${audit.accessionNumber}\nform: ${audit.form}\nexact value: ${raw}`
-                : `exact value: ${raw}`;
-              return `<td class="${derived}" title="${esc(tip)}"><span class="val">${esc(text)}</span>` +
-                (showTags && audit ? `<span class="tag">${esc(audit.tag)}</span>` : '') + `</td>`;
-            }).join('');
-            return `<tr><td class="metric">${esc(label)}</td>${cells}</tr>`;
+          const rows = fields.map(([key, label]) => {
+            if (!periods.some((p) => p[key] !== null && p[key] !== undefined)) return '';
+            return `<tr><td class="metric">${esc(label)}</td>${periods.map((p) => cellHtml(p, key)).join('')}</tr>`;
           }).join('');
           if (!rows) return '';
           return `<section class="group"><h2>${esc(GROUP_TITLES[g])}</h2><div class="scroll"><table>` +
@@ -330,7 +371,8 @@
         const warnHtml = (data.warnings || [])
           .map((w) => `<div class="banner">⚠ ${esc(w)}</div>`)
           .join('');
-        document.getElementById('sections').innerHTML = warnHtml + filingsHtml + groupsHtml;
+        document.getElementById('sections').innerHTML =
+          warnHtml + filingsHtml + groupsHtml + renderCashFlow(periods, yearHeads);
         renderRatios(periods);
         initWacc(periods[0]);
         document.getElementById('raw').textContent = JSON.stringify(data, null, 2);

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -67,6 +67,14 @@
       td.derived .val::after { content: " ∗"; color: var(--warn); }
       tr.cf-sub td { font-weight: 700; border-top: 1px solid var(--line); background: rgba(76, 196, 255, 0.05); }
       tr.cf-sub td.metric { background: #16243f; }
+      tr.bs-header td.metric { font-weight: 800; color: var(--accent); text-transform: none; padding-top: 0.5rem; }
+      tr.bs-item td.metric { color: var(--text); font-weight: 400; }
+      tr.bs-sub td { color: var(--muted); font-size: 0.8rem; }
+      tr.bs-subtotal td { font-weight: 700; border-top: 1px solid var(--line); }
+      tr.bs-subtotal td.metric { background: #16243f; }
+      tr.bs-grand td { font-weight: 800; border-top: 2px solid var(--accent); border-bottom: 2px solid var(--accent); color: var(--accent); }
+      tr.bs-grand td.metric { background: #16243f; }
+      tr.bs-check td { font-size: 0.78rem; color: var(--muted); }
       td .tag, td.tagcol .tag { display: block; font-size: 0.68rem; color: var(--muted); margin-top: 0.05rem; }
       .na { color: #56688a; }
       .allctrl { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; margin-bottom: 0.6rem; }
@@ -336,6 +344,104 @@
         }).join('');
       }
 
+      // Companies Act 2013, Schedule III (Division I) vertical balance sheet.
+      // Mirrors server/src/balanceSheet.js: SEC control totals are authoritative,
+      // balancing "Other" lines absorb unmapped items so every group reconciles.
+      function scheduleIII(period) {
+        const v = period || {};
+        const n = (x) => (typeof x === 'number' && isFinite(x) ? x : null);
+        const add = (arr) => { let s = 0, any = false; for (const x of arr) if (x != null) { s += x; any = true; } return any ? s : null; };
+        const resid = (ctrl, parts) => (ctrl == null ? add(parts) : ctrl - (add(parts) || 0));
+
+        const totalAssets = n(v.totalAssets), currentAssets = n(v.currentAssets);
+        const totalLiab = n(v.totalLiabilities), currentLiab = n(v.currentLiabilities);
+        const equity = n(v.stockholdersEquity);
+        const nca = totalAssets != null && currentAssets != null ? totalAssets - currentAssets : null;
+        const ncl = totalLiab != null && currentLiab != null ? totalLiab - currentLiab : null;
+
+        const ppe = n(v.propertyPlantEquipmentNet), intang = n(v.intangibleAssets), gw = n(v.goodwill);
+        const otherNCA = resid(nca, [ppe, intang, gw]);
+        const cash = n(v.cashAndEquivalents), curInv = n(v.shortTermInvestments), inv = n(v.inventory), recv = n(v.accountsReceivable);
+        const otherCA = resid(currentAssets, [cash, curInv, inv, recv]);
+
+        const shareCap = add([n(v.commonStockValue), n(v.additionalPaidInCapital)]);
+        const reserves = equity != null ? equity - (shareCap || 0) : null;
+        const otherRes = resid(reserves, [n(v.retainedEarnings), n(v.treasuryStock), n(v.accumulatedOCI)]);
+        const ltb = n(v.longTermDebt), dtl = n(v.deferredTaxLiabilities);
+        const otherLTL = resid(ncl, [ltb, dtl]);
+        const stb = n(v.shortTermDebt), tp = n(v.accountsPayable);
+        const otherCL = resid(currentLiab, [stb, tp]);
+
+        const elTotal = add([equity, totalLiab]);
+        const diff = totalAssets != null && elTotal != null ? totalAssets - elTotal : null;
+        const balances = diff == null ? null : Math.abs(diff) <= Math.max(1, Math.abs(totalAssets || 0) * 0.005);
+
+        const L = (label, kind, level, value) => ({ label, kind, level, value });
+        const lines = [
+          L('I. EQUITY AND LIABILITIES', 'header', 0, null),
+          L('(1) Shareholders’ Funds', 'header', 1, null),
+          L('(a) Share Capital', 'item', 2, shareCap),
+          L('(b) Reserves & Surplus', 'item', 2, reserves),
+          L('Retained earnings', 'sub', 3, n(v.retainedEarnings)),
+          L('Treasury stock', 'sub', 3, n(v.treasuryStock)),
+          L('Other comprehensive income', 'sub', 3, n(v.accumulatedOCI)),
+          L('Other reserves (balancing)', 'sub', 3, otherRes),
+          L('Total Shareholders’ Funds', 'subtotal', 1, equity),
+          L('(2) Non-Current Liabilities', 'header', 1, null),
+          L('(a) Long-term borrowings', 'item', 2, ltb),
+          L('(b) Deferred tax liabilities (net)', 'item', 2, dtl),
+          L('(c) Other long-term liabilities & provisions', 'item', 2, otherLTL),
+          L('Total Non-Current Liabilities', 'subtotal', 1, ncl),
+          L('(3) Current Liabilities', 'header', 1, null),
+          L('(a) Short-term borrowings', 'item', 2, stb),
+          L('(b) Trade payables', 'item', 2, tp),
+          L('(c) Other current liabilities & provisions', 'item', 2, otherCL),
+          L('Total Current Liabilities', 'subtotal', 1, currentLiab),
+          L('TOTAL EQUITY AND LIABILITIES', 'grandtotal', 0, elTotal),
+          L('II. ASSETS', 'header', 0, null),
+          L('(1) Non-Current Assets', 'header', 1, null),
+          L('(a) Property, Plant & Equipment', 'item', 2, ppe),
+          L('(b) Intangible assets', 'item', 2, intang),
+          L('(c) Goodwill', 'item', 2, gw),
+          L('(d) Other non-current assets', 'item', 2, otherNCA),
+          L('Total Non-Current Assets', 'subtotal', 1, nca),
+          L('(2) Current Assets', 'header', 1, null),
+          L('(a) Current investments', 'item', 2, curInv),
+          L('(b) Inventories', 'item', 2, inv),
+          L('(c) Trade receivables', 'item', 2, recv),
+          L('(d) Cash & cash equivalents', 'item', 2, cash),
+          L('(e) Other current assets', 'item', 2, otherCA),
+          L('Total Current Assets', 'subtotal', 1, currentAssets),
+          L('TOTAL ASSETS', 'grandtotal', 0, totalAssets),
+        ];
+        return { lines, balances, difference: diff };
+      }
+      function renderBalanceSheet(periods, yearHeads) {
+        if (!periods.length) return '';
+        const schedules = periods.map(scheduleIII);
+        const lines = schedules[0].lines;
+        const body = lines.map((ln, idx) => {
+          const cls = { header: 'bs-header', subtotal: 'bs-subtotal', grandtotal: 'bs-grand', sub: 'bs-sub', item: 'bs-item' }[ln.kind] || '';
+          const pad = (0.5 + ln.level * 1.1).toFixed(2);
+          const cells = (ln.kind === 'header' && ln.value == null)
+            ? periods.map(() => '<td></td>').join('')
+            : schedules.map((s) => {
+                const v = s.lines[idx].value;
+                return `<td>${v == null ? '<span class="na">—</span>' : esc(fmtByUnit('USD', v))}</td>`;
+              }).join('');
+          return `<tr class="${cls}"><td class="metric" style="padding-left:${pad}rem">${esc(ln.label)}</td>${cells}</tr>`;
+        }).join('');
+        const checkCells = schedules.map((s) =>
+          s.balances == null ? '<td class="na">—</td>'
+            : s.balances ? '<td style="color:var(--good)">✓ balances</td>'
+              : `<td style="color:var(--bad)">off ${esc(fmtByUnit('USD', s.difference))}</td>`).join('');
+        const checkRow = `<tr class="bs-check"><td class="metric" style="padding-left:0.5rem">Balance check (Assets = Equity + Liabilities)</td>${checkCells}</tr>`;
+        return `<section class="group"><h2>Balance Sheet — Companies Act 2013, Schedule III (vertical)</h2>` +
+          `<div class="scroll"><table><thead><tr><th class="metric">Particulars</th>${yearHeads}</tr></thead>` +
+          `<tbody>${body}${checkRow}</tbody></table></div>` +
+          `<p class="legend">Recast from US-GAAP into Schedule III buckets. SEC-reported control totals are authoritative; "Other …" lines absorb company-specific items (e.g. content liabilities) so every subtotal and the grand total reconcile.</p></section>`;
+      }
+
       // ---- curated model rendering -----------------------------------------
       function render(data) {
         const periods = data.periods || [];
@@ -357,8 +463,9 @@
           periods.map((p) => `<td class="na">${esc(p.accessionNumber || '—')}</td>`).join('') + `</tr>` +
           `</tbody></table></div></section>`;
 
-        // Income statement, per-share and balance sheet render as flat tables.
-        const groupsHtml = ['inc', 'ps', 'bs'].map((g) => {
+        // Income statement and per-share render as flat tables; the balance
+        // sheet is recast into the Schedule III vertical format below.
+        const groupsHtml = ['inc', 'ps'].map((g) => {
           const fields = FIELD_DEFS.filter((f) => f[2] === g);
           const rows = fields.map(([key, label]) => {
             if (!periods.some((p) => p[key] !== null && p[key] !== undefined)) return '';
@@ -373,7 +480,8 @@
           .map((w) => `<div class="banner">⚠ ${esc(w)}</div>`)
           .join('');
         document.getElementById('sections').innerHTML =
-          warnHtml + filingsHtml + groupsHtml + renderCashFlow(periods, yearHeads);
+          warnHtml + filingsHtml + groupsHtml + renderBalanceSheet(periods, yearHeads) +
+          renderCashFlow(periods, yearHeads);
         renderRatios(periods);
         initWacc(periods[0]);
         document.getElementById('raw').textContent = JSON.stringify(data, null, 2);

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -1,0 +1,34 @@
+const path = require('path');
+const express = require('express');
+const { createRouter } = require('./routes');
+
+function createApp({ service }) {
+  const app = express();
+  app.use(express.json());
+
+  app.use('/api/sec', createRouter({ service }));
+
+  // Serve the simple frontend.
+  app.use(express.static(path.join(__dirname, '..', 'public')));
+
+  // 404 for unmatched API routes.
+  app.use('/api', (req, res) => {
+    res.status(404).json({ error: `Not found: ${req.method} ${req.originalUrl}` });
+  });
+
+  // Centralized error handler.
+  // eslint-disable-next-line no-unused-vars
+  app.use((err, req, res, next) => {
+    const status = err.status || 500;
+    const message = err.expose || status < 500 ? err.message : 'Internal server error';
+    if (status >= 500) {
+      // eslint-disable-next-line no-console
+      console.error(err);
+    }
+    res.status(status).json({ error: message });
+  });
+
+  return app;
+}
+
+module.exports = { createApp };

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -6,6 +6,18 @@ function createApp({ service }) {
   const app = express();
   app.use(express.json());
 
+  // Read-only, no-auth public data: permissive CORS so the UI works whether it
+  // is served by this backend or opened directly as a file.
+  app.use((req, res, next) => {
+    res.header('Access-Control-Allow-Origin', '*');
+    res.header('Access-Control-Allow-Methods', 'GET, OPTIONS');
+    res.header('Access-Control-Allow-Headers', 'Content-Type');
+    if (req.method === 'OPTIONS') {
+      return res.sendStatus(204);
+    }
+    return next();
+  });
+
   app.use('/api/sec', createRouter({ service }));
 
   // Serve the simple frontend.

--- a/server/src/balanceSheet.js
+++ b/server/src/balanceSheet.js
@@ -1,0 +1,135 @@
+// Recast a normalized (US-GAAP) period into the vertical Balance Sheet format of
+// Schedule III, Division I of the Companies Act, 2013.
+//
+// Logic: the SEC-reported control totals are authoritative — Total Assets,
+// Current Assets, Total Liabilities, Current Liabilities and Shareholders'
+// Equity. Mapped US-GAAP line items are slotted into the Schedule III buckets,
+// and a balancing "Other …" line in each group absorbs whatever isn't mapped
+// (e.g. a streaming company's content liabilities). This guarantees every
+// subtotal and the grand total reconcile, and Total Assets = Total Equity & Liabilities.
+
+const num = (x) => (typeof x === 'number' && Number.isFinite(x) ? x : null);
+
+// Sum that returns null only if every input is null (so 0 + null = 0).
+function addable(values) {
+  let sum = 0;
+  let any = false;
+  for (const v of values) {
+    if (v != null) {
+      sum += v;
+      any = true;
+    }
+  }
+  return any ? sum : null;
+}
+
+// Residual = control - sum(parts); null only when the control total is missing.
+function residual(control, parts) {
+  if (control == null) return addable(parts);
+  return control - (addable(parts) || 0);
+}
+
+function computeScheduleIII(period) {
+  const v = period || {};
+  const totalAssets = num(v.totalAssets);
+  const currentAssets = num(v.currentAssets);
+  const totalLiabilities = num(v.totalLiabilities);
+  const currentLiabilities = num(v.currentLiabilities);
+  const equity = num(v.stockholdersEquity);
+
+  const nonCurrentAssets =
+    totalAssets != null && currentAssets != null ? totalAssets - currentAssets : null;
+  const nonCurrentLiabilities =
+    totalLiabilities != null && currentLiabilities != null
+      ? totalLiabilities - currentLiabilities
+      : null;
+
+  // Assets
+  const ppe = num(v.propertyPlantEquipmentNet);
+  const intangibles = num(v.intangibleAssets);
+  const goodwill = num(v.goodwill);
+  const otherNonCurrentAssets = residual(nonCurrentAssets, [ppe, intangibles, goodwill]);
+
+  const cash = num(v.cashAndEquivalents);
+  const currentInvestments = num(v.shortTermInvestments);
+  const inventories = num(v.inventory);
+  const receivables = num(v.accountsReceivable);
+  const otherCurrentAssets = residual(currentAssets, [cash, currentInvestments, inventories, receivables]);
+
+  // Equity & Liabilities
+  const shareCapital = addable([num(v.commonStockValue), num(v.additionalPaidInCapital)]);
+  const reservesTotal = equity != null ? equity - (shareCapital || 0) : null;
+  const retained = num(v.retainedEarnings);
+  const treasury = num(v.treasuryStock);
+  const aoci = num(v.accumulatedOCI);
+  const otherReserves = residual(reservesTotal, [retained, treasury, aoci]);
+
+  const longTermBorrowings = num(v.longTermDebt);
+  const deferredTax = num(v.deferredTaxLiabilities);
+  const otherLongTermLiabilities = residual(nonCurrentLiabilities, [longTermBorrowings, deferredTax]);
+
+  const shortTermBorrowings = num(v.shortTermDebt);
+  const tradePayables = num(v.accountsPayable);
+  const otherCurrentLiabilities = residual(currentLiabilities, [shortTermBorrowings, tradePayables]);
+
+  const totalEquityAndLiabilities = addable([equity, totalLiabilities]);
+  const difference =
+    totalAssets != null && totalEquityAndLiabilities != null
+      ? totalAssets - totalEquityAndLiabilities
+      : null;
+  // Tolerate rounding / minority-interest noise up to 0.5% of assets.
+  const balances =
+    difference == null ? null : Math.abs(difference) <= Math.max(1, Math.abs(totalAssets || 0) * 0.005);
+
+  const L = (key, label, kind, level, value) => ({ key, label, kind, level, value });
+
+  const lines = [
+    L('el', 'I. EQUITY AND LIABILITIES', 'header', 0, null),
+    L('sf', '(1) Shareholders’ Funds', 'header', 1, null),
+    L('shareCapital', '(a) Share Capital', 'item', 2, shareCapital),
+    L('reserves', '(b) Reserves & Surplus', 'item', 2, reservesTotal),
+    L('retained', 'Retained earnings', 'sub', 3, retained),
+    L('treasury', 'Treasury stock', 'sub', 3, treasury),
+    L('aoci', 'Other comprehensive income', 'sub', 3, aoci),
+    L('otherReserves', 'Other reserves (balancing)', 'sub', 3, otherReserves),
+    L('sfTotal', 'Total Shareholders’ Funds', 'subtotal', 1, equity),
+    L('ncl', '(2) Non-Current Liabilities', 'header', 1, null),
+    L('longTermBorrowings', '(a) Long-term borrowings', 'item', 2, longTermBorrowings),
+    L('deferredTax', '(b) Deferred tax liabilities (net)', 'item', 2, deferredTax),
+    L('otherLongTermLiabilities', '(c) Other long-term liabilities & provisions', 'item', 2, otherLongTermLiabilities),
+    L('nclTotal', 'Total Non-Current Liabilities', 'subtotal', 1, nonCurrentLiabilities),
+    L('cl', '(3) Current Liabilities', 'header', 1, null),
+    L('shortTermBorrowings', '(a) Short-term borrowings', 'item', 2, shortTermBorrowings),
+    L('tradePayables', '(b) Trade payables', 'item', 2, tradePayables),
+    L('otherCurrentLiabilities', '(c) Other current liabilities & provisions', 'item', 2, otherCurrentLiabilities),
+    L('clTotal', 'Total Current Liabilities', 'subtotal', 1, currentLiabilities),
+    L('elTotal', 'TOTAL EQUITY AND LIABILITIES', 'grandtotal', 0, totalEquityAndLiabilities),
+
+    L('as', 'II. ASSETS', 'header', 0, null),
+    L('nca', '(1) Non-Current Assets', 'header', 1, null),
+    L('ppe', '(a) Property, Plant & Equipment', 'item', 2, ppe),
+    L('intangibles', '(b) Intangible assets', 'item', 2, intangibles),
+    L('goodwill', '(c) Goodwill', 'item', 2, goodwill),
+    L('otherNonCurrentAssets', '(d) Other non-current assets', 'item', 2, otherNonCurrentAssets),
+    L('ncaTotal', 'Total Non-Current Assets', 'subtotal', 1, nonCurrentAssets),
+    L('ca', '(2) Current Assets', 'header', 1, null),
+    L('currentInvestments', '(a) Current investments', 'item', 2, currentInvestments),
+    L('inventories', '(b) Inventories', 'item', 2, inventories),
+    L('receivables', '(c) Trade receivables', 'item', 2, receivables),
+    L('cash', '(d) Cash & cash equivalents', 'item', 2, cash),
+    L('otherCurrentAssets', '(e) Other current assets', 'item', 2, otherCurrentAssets),
+    L('caTotal', 'Total Current Assets', 'subtotal', 1, currentAssets),
+    L('asTotal', 'TOTAL ASSETS', 'grandtotal', 0, totalAssets),
+  ];
+
+  return {
+    fiscalYear: v.fiscalYear,
+    lines,
+    totalAssets,
+    totalEquityAndLiabilities,
+    difference,
+    balances,
+  };
+}
+
+module.exports = { buildScheduleIII: computeScheduleIII };

--- a/server/src/cache.js
+++ b/server/src/cache.js
@@ -1,0 +1,30 @@
+// Minimal in-memory TTL cache. Sufficient for a single-process education app;
+// swap for Redis/etc. if this ever needs to scale horizontally.
+function createCache(ttlMs) {
+  const store = new Map();
+  return {
+    get(key) {
+      const entry = store.get(key);
+      if (!entry) return undefined;
+      if (Date.now() > entry.expires) {
+        store.delete(key);
+        return undefined;
+      }
+      return entry.value;
+    },
+    set(key, value) {
+      store.set(key, { value, expires: Date.now() + ttlMs });
+    },
+    has(key) {
+      return this.get(key) !== undefined;
+    },
+    clear() {
+      store.clear();
+    },
+    get size() {
+      return store.size;
+    },
+  };
+}
+
+module.exports = { createCache };

--- a/server/src/cikLookup.js
+++ b/server/src/cikLookup.js
@@ -1,0 +1,31 @@
+// Ticker <-> CIK helpers.
+
+// SEC CIKs are numeric but the JSON APIs expect them zero-padded to 10 digits,
+// e.g. 1065280 -> "0001065280".
+function padCik(cik) {
+  const digits = String(cik).replace(/\D/g, '');
+  if (!digits) {
+    throw new Error(`Invalid CIK: ${cik}`);
+  }
+  return digits.padStart(10, '0');
+}
+
+// The data.sec.gov path segment, e.g. 1065280 -> "CIK0001065280".
+function cikUrlParam(cik) {
+  return `CIK${padCik(cik)}`;
+}
+
+// company_tickers.json is keyed by an arbitrary index:
+// { "0": { "cik_str": 320193, "ticker": "AAPL", "title": "Apple Inc." }, ... }
+function findTickerEntry(mapping, ticker) {
+  const target = String(ticker).trim().toUpperCase();
+  if (!target) return null;
+  for (const entry of Object.values(mapping || {})) {
+    if (entry && String(entry.ticker).toUpperCase() === target) {
+      return entry;
+    }
+  }
+  return null;
+}
+
+module.exports = { padCik, cikUrlParam, findTickerEntry };

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -1,0 +1,29 @@
+// Loads configuration from the environment. dotenv is optional so the server
+// (and the tests) still run if it has not been installed.
+try {
+  // eslint-disable-next-line global-require
+  require('dotenv').config();
+} catch (_) {
+  /* dotenv is an optional convenience dependency */
+}
+
+const contactEmail = process.env.SEC_CONTACT_EMAIL || 'gordeswapnil@gmail.com';
+const appName = process.env.SEC_APP_NAME || 'FinancialModellingEducationApp';
+
+module.exports = {
+  port: Number(process.env.PORT) || 3000,
+  contactEmail,
+  appName,
+  // SEC fair-access policy requires a descriptive User-Agent that identifies
+  // the application and a contact address. The email is env-driven so it can
+  // be replaced without code changes.
+  userAgent: `${appName} ${contactEmail}`,
+  acceptEncoding: 'gzip, deflate',
+  // Cache SEC responses to avoid repeatedly hitting their servers for the same
+  // ticker. Defaults to 24h since 10-K data changes at most a few times a year.
+  cacheTtlMs: Number(process.env.SEC_CACHE_TTL_MS) || 24 * 60 * 60 * 1000,
+  // SEC allows up to 10 requests/second. We stay at or below this.
+  maxRequestsPerSecond: Number(process.env.SEC_MAX_RPS) || 10,
+  maxRetries: Number(process.env.SEC_MAX_RETRIES) || 4,
+  baseBackoffMs: Number(process.env.SEC_BASE_BACKOFF_MS) || 500,
+};

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -11,7 +11,7 @@ const contactEmail = process.env.SEC_CONTACT_EMAIL || 'gordeswapnil@gmail.com';
 const appName = process.env.SEC_APP_NAME || 'FinancialModellingEducationApp';
 
 module.exports = {
-  port: Number(process.env.PORT) || 3000,
+  port: Number(process.env.PORT) || 5050,
   contactEmail,
   appName,
   // SEC fair-access policy requires a descriptive User-Agent that identifies

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -26,4 +26,18 @@ module.exports = {
   maxRequestsPerSecond: Number(process.env.SEC_MAX_RPS) || 10,
   maxRetries: Number(process.env.SEC_MAX_RETRIES) || 4,
   baseBackoffMs: Number(process.env.SEC_BASE_BACKOFF_MS) || 500,
+
+  // ---- WACC / market data (non-SEC) -------------------------------------
+  // Beta and market capitalisation are not in SEC data. They come from a
+  // pluggable market-data provider (default: Alpha Vantage). Get a free key at
+  // https://www.alphavantage.co/support/#api-key and set ALPHAVANTAGE_API_KEY.
+  marketDataProvider: process.env.MARKET_DATA_PROVIDER || 'alphavantage',
+  alphaVantageApiKey: process.env.ALPHAVANTAGE_API_KEY || '',
+  alphaVantageBaseUrl: process.env.ALPHAVANTAGE_BASE_URL || 'https://www.alphavantage.co',
+
+  // Risk-free rate: pulled free (no key) from the US Treasury par-yield feed,
+  // with a sensible fallback if the feed is unreachable. Override per-request.
+  riskFreeRateDefault: Number(process.env.RISK_FREE_RATE) || 0.043,
+  // Equity risk premium is a market assumption, not a data point.
+  equityRiskPremiumDefault: Number(process.env.EQUITY_RISK_PREMIUM) || 0.055,
 };

--- a/server/src/damodaran.js
+++ b/server/src/damodaran.js
@@ -1,0 +1,134 @@
+const fs = require('fs');
+
+// Industry (un)levered betas in the spirit of Aswath Damodaran's freely
+// published NYU Stern dataset. Beta is NOT in SEC data and a single-stock
+// regression beta is noisy, so for teaching we use an INDUSTRY unlevered beta
+// and re-lever it with the company's own capital structure and tax rate.
+//
+// IMPORTANT: the values below are APPROXIMATE seed values for offline use. For
+// real analysis, download the current "Levered and Unlevered Betas by Industry
+// (US)" table from https://pages.stern.nyu.edu/~adamodar/ and point
+// DAMODARAN_DATA_PATH at a JSON file of { "Industry Name": unleveredBeta, ... }.
+const SEED = {
+  vintage: 'approximate seed (~2024) — replace with official Damodaran data',
+  region: 'US',
+  // unlevered (asset) betas by industry
+  unlevered: {
+    'Total Market': 0.78,
+    Entertainment: 1.1,
+    'Software (System & Application)': 1.13,
+    'Software (Internet)': 1.4,
+    'Computers/Peripherals': 1.05,
+    'Semiconductor': 1.55,
+    'Drugs (Pharmaceutical)': 1.05,
+    'Healthcare Products': 0.9,
+    'Retail (General)': 1.1,
+    'Retail (Online)': 1.45,
+    'Bank (Money Center)': 0.45,
+    'Insurance (General)': 0.55,
+    'Auto & Truck': 1.3,
+    'Aerospace/Defense': 1.05,
+    'Telecom Services': 0.8,
+    'Food Processing': 0.55,
+    'Beverage (Soft)': 0.6,
+    'Oil/Gas (Production)': 0.95,
+    'Utility (General)': 0.4,
+    'Hotel/Gaming': 1.25,
+    'Restaurant/Dining': 1.25,
+    'Apparel': 1.05,
+    'Advertising': 1.1,
+    'Air Transport': 1.2,
+    'Chemical (Basic)': 0.95,
+    'Real Estate (REIT)': 0.7,
+    'Machinery': 1.05,
+    'Household Products': 0.7,
+  },
+};
+
+// Map an SIC code to one of the industries above. Coarse but reasonable.
+function sicToIndustry(sic) {
+  const code = Number(String(sic || '').trim());
+  if (!Number.isFinite(code) || code === 0) return null;
+  const inRange = (lo, hi) => code >= lo && code <= hi;
+
+  if (inRange(7800, 7899) || inRange(7900, 7999)) return 'Entertainment';
+  if (inRange(7370, 7379)) return 'Software (System & Application)';
+  if (code === 7370 || inRange(5961, 5961)) return 'Retail (Online)';
+  if (inRange(3570, 3579) || inRange(3680, 3689)) return 'Computers/Peripherals';
+  if (inRange(3670, 3679) || code === 3674) return 'Semiconductor';
+  if (inRange(2830, 2836) || code === 2834) return 'Drugs (Pharmaceutical)';
+  if (inRange(3840, 3851)) return 'Healthcare Products';
+  if (inRange(5200, 5999)) return 'Retail (General)';
+  if (inRange(6020, 6099)) return 'Bank (Money Center)';
+  if (inRange(6300, 6411)) return 'Insurance (General)';
+  if (inRange(3710, 3716)) return 'Auto & Truck';
+  if (inRange(3720, 3728) || inRange(3760, 3769)) return 'Aerospace/Defense';
+  if (inRange(4810, 4899)) return 'Telecom Services';
+  if (inRange(2000, 2099)) return 'Food Processing';
+  if (inRange(2080, 2086)) return 'Beverage (Soft)';
+  if (inRange(1310, 1389) || inRange(2900, 2999)) return 'Oil/Gas (Production)';
+  if (inRange(4900, 4991)) return 'Utility (General)';
+  if (inRange(7000, 7021)) return 'Hotel/Gaming';
+  if (inRange(5812, 5813)) return 'Restaurant/Dining';
+  if (inRange(2200, 2399) || inRange(3100, 3199)) return 'Apparel';
+  if (inRange(7310, 7319)) return 'Advertising';
+  if (inRange(4500, 4581)) return 'Air Transport';
+  if (inRange(2800, 2899)) return 'Chemical (Basic)';
+  if (inRange(6500, 6553)) return 'Real Estate (REIT)';
+  if (inRange(3500, 3569)) return 'Machinery';
+  if (inRange(2840, 2844) || code === 2840) return 'Household Products';
+  return null;
+}
+
+function loadDataset() {
+  const path = process.env.DAMODARAN_DATA_PATH;
+  if (path) {
+    try {
+      const raw = JSON.parse(fs.readFileSync(path, 'utf8'));
+      // Accept either { unlevered: {...} } or a flat { industry: beta } map.
+      const unlevered = raw.unlevered || raw;
+      return {
+        vintage: raw.vintage || `custom (${path})`,
+        region: raw.region || 'US',
+        unlevered,
+      };
+    } catch (_) {
+      /* fall back to seed */
+    }
+  }
+  return SEED;
+}
+
+// Re-lever an industry asset beta with the firm's capital structure:
+//   beta_levered = beta_unlevered * (1 + (1 - taxRate) * (D / E))
+function relever(unlevered, { de, taxRate }) {
+  if (unlevered == null) return null;
+  if (de == null || !Number.isFinite(de) || de < 0) return unlevered;
+  const t = Number.isFinite(taxRate) ? taxRate : 0;
+  return unlevered * (1 + (1 - t) * de);
+}
+
+// Resolve an industry beta for a company.
+function getIndustryBeta({ sic, de, taxRate, dataset = loadDataset() } = {}) {
+  let industry = sicToIndustry(sic);
+  let matchedBy = 'sic';
+  if (!industry || dataset.unlevered[industry] == null) {
+    industry = 'Total Market';
+    matchedBy = 'fallback';
+  }
+  const unleveredBeta = dataset.unlevered[industry];
+  const releveredBeta = relever(unleveredBeta, { de, taxRate });
+  return {
+    industry,
+    matchedBy,
+    unleveredBeta,
+    releveredBeta,
+    deRatioUsed: de != null && Number.isFinite(de) ? de : null,
+    taxRateUsed: Number.isFinite(taxRate) ? taxRate : null,
+    vintage: dataset.vintage,
+    region: dataset.region,
+    source: 'damodaran-industry',
+  };
+}
+
+module.exports = { getIndustryBeta, sicToIndustry, relever, loadDataset, SEED };

--- a/server/src/errors.js
+++ b/server/src/errors.js
@@ -1,0 +1,15 @@
+// Small helpers for HTTP-aware errors. `expose` marks messages that are safe
+// to return to the client.
+function httpError(status, message) {
+  const err = new Error(message);
+  err.status = status;
+  err.expose = true;
+  return err;
+}
+
+module.exports = {
+  httpError,
+  badRequest: (message) => httpError(400, message),
+  notFound: (message) => httpError(404, message),
+  badGateway: (message) => httpError(502, message),
+};

--- a/server/src/filingText.js
+++ b/server/src/filingText.js
@@ -3,27 +3,60 @@
 // the Business section out by its item headers. Heuristic by nature — always
 // link back to the source filing.
 
-function htmlToText(html) {
-  if (!html || typeof html !== 'string') return '';
-  return html
-    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
-    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/&nbsp;|&#160;|&#xa0;/gi, ' ')
+function codePoint(n) {
+  try {
+    return String.fromCodePoint(n);
+  } catch (_) {
+    return ' ';
+  }
+}
+
+// Decode numeric (&#174; &#x2122;) and common named HTML entities.
+function decodeEntities(s) {
+  return s
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, h) => codePoint(parseInt(h, 16)))
+    .replace(/&#(\d+);/g, (_, d) => codePoint(parseInt(d, 10)))
+    .replace(/&nbsp;/gi, ' ')
     .replace(/&amp;/gi, '&')
     .replace(/&lt;/gi, '<')
     .replace(/&gt;/gi, '>')
-    .replace(/&#8217;|&#x2019;|&rsquo;/gi, "'")
-    .replace(/&#8216;|&lsquo;/gi, "'")
-    .replace(/&#8220;|&#8221;|&ldquo;|&rdquo;/gi, '"')
-    .replace(/&#8212;|&mdash;/gi, '—')
-    .replace(/&[a-z]+;/gi, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
+    .replace(/&quot;/gi, '"')
+    .replace(/&rsquo;|&lsquo;/gi, "'")
+    .replace(/&ldquo;|&rdquo;/gi, '"')
+    .replace(/&mdash;|&ndash;/gi, '—')
+    .replace(/&[a-zA-Z]+;/g, ' ');
+}
+
+function htmlToText(html) {
+  if (!html || typeof html !== 'string') return '';
+  let t = html
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ');
+  t = decodeEntities(t);
+  return t.replace(/\s+/g, ' ').trim();
+}
+
+// Common Item 1 sub-headings; we insert a paragraph break before them so the
+// extracted prose isn't a single wall of text.
+const SUBHEADINGS = [
+  'Company Background', 'Products', 'Services', 'Segments', 'Markets and Distribution',
+  'Competition', 'Supply of Components', 'Research and Development', 'Intellectual Property',
+  'Patents', 'Business Seasonality', 'Human Capital', 'Employees', 'Government Regulation',
+  'Environmental', 'Available Information', 'Seasonality',
+];
+const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+function addParagraphBreaks(text) {
+  let out = text;
+  for (const h of SUBHEADINGS) {
+    out = out.replace(new RegExp('\\.\\s+(' + escapeRe(h) + ')\\s', 'g'), '.\n\n$1 ');
+  }
+  return out;
 }
 
 // Returns { excerpt, length, truncated } or null if the section isn't found.
-function extractBusinessSection(html, { maxChars = 4000 } = {}) {
+function extractBusinessSection(html, { maxChars = 6000 } = {}) {
   const text = htmlToText(html);
   if (!text) return null;
 
@@ -42,7 +75,7 @@ function extractBusinessSection(html, { maxChars = 4000 } = {}) {
   const endMatch = endRe.exec(text);
   const end = endMatch ? endMatch.index : Math.min(text.length, start + maxChars * 3);
 
-  let section = text.slice(start, end).trim();
+  let section = addParagraphBreaks(text.slice(start, end).trim());
   if (!section) return null;
 
   const length = section.length;
@@ -54,4 +87,4 @@ function extractBusinessSection(html, { maxChars = 4000 } = {}) {
   return { excerpt: section, length, truncated };
 }
 
-module.exports = { extractBusinessSection, htmlToText };
+module.exports = { extractBusinessSection, htmlToText, decodeEntities };

--- a/server/src/filingText.js
+++ b/server/src/filingText.js
@@ -1,0 +1,57 @@
+// Best-effort extraction of the "Item 1 — Business" narrative from a 10-K
+// document. The filing is (inline-XBRL) HTML; we strip markup to text and slice
+// the Business section out by its item headers. Heuristic by nature — always
+// link back to the source filing.
+
+function htmlToText(html) {
+  if (!html || typeof html !== 'string') return '';
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;|&#160;|&#xa0;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&#8217;|&#x2019;|&rsquo;/gi, "'")
+    .replace(/&#8216;|&lsquo;/gi, "'")
+    .replace(/&#8220;|&#8221;|&ldquo;|&rdquo;/gi, '"')
+    .replace(/&#8212;|&mdash;/gi, '—')
+    .replace(/&[a-z]+;/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+// Returns { excerpt, length, truncated } or null if the section isn't found.
+function extractBusinessSection(html, { maxChars = 4000 } = {}) {
+  const text = htmlToText(html);
+  if (!text) return null;
+
+  // Find all "Item 1. Business" headers; the real section is the last one
+  // (earlier hits are the table of contents). Allow optional period and spacing.
+  const startRe = /item\s*1\.?\s*[-:.]?\s*business/gi;
+  const starts = [];
+  let m;
+  while ((m = startRe.exec(text)) !== null) starts.push(m.index);
+  if (!starts.length) return null;
+  const start = starts[starts.length - 1];
+
+  // End at the next "Item 1A ... Risk Factors" (or Item 2 Properties) after start.
+  const endRe = /item\s*1a\.?\s*[-:.]?\s*risk\s*factors|item\s*2\.?\s*[-:.]?\s*properties|item\s*1b\.?\s*[-:.]?\s*unresolved/gi;
+  endRe.lastIndex = start + 1;
+  const endMatch = endRe.exec(text);
+  const end = endMatch ? endMatch.index : Math.min(text.length, start + maxChars * 3);
+
+  let section = text.slice(start, end).trim();
+  if (!section) return null;
+
+  const length = section.length;
+  let truncated = false;
+  if (section.length > maxChars) {
+    section = section.slice(0, maxChars).replace(/\s+\S*$/, '') + '…';
+    truncated = true;
+  }
+  return { excerpt: section, length, truncated };
+}
+
+module.exports = { extractBusinessSection, htmlToText };

--- a/server/src/incomeStatement.js
+++ b/server/src/incomeStatement.js
@@ -1,0 +1,91 @@
+// Recast a normalized (US-GAAP) period into the vertical Statement of Profit &
+// Loss of Schedule III, Division I, Part II of the Companies Act, 2013.
+//
+// US-GAAP statements use FUNCTIONAL classification (cost of revenue, R&D, SG&A);
+// Schedule III uses NATURAL heads (materials, finance costs, other expenses).
+// We anchor on Profit Before Tax (authoritative), build:
+//   Total Income   = Revenue from operations + Other income
+//   Total Expenses = Total Income − Profit Before Tax        (reconciling)
+// then list the separable natural heads (cost of revenue, finance costs) and let
+// "Other expenses" absorb the rest (operating expenses, D&A embedded in them,
+// employee benefits, etc.). Guarantees Total Income − Total Expenses = PBT.
+
+const num = (x) => (typeof x === 'number' && Number.isFinite(x) ? x : null);
+
+function addable(values) {
+  let sum = 0;
+  let any = false;
+  for (const v of values) {
+    if (v != null) {
+      sum += v;
+      any = true;
+    }
+  }
+  return any ? sum : null;
+}
+
+function computeScheduleIIIPL(period) {
+  const v = period || {};
+
+  const revenue = num(v.revenue);
+  const otherIncome = addable([num(v.interestIncome), num(v.otherIncomeExpense)]);
+  const totalIncome = addable([revenue, otherIncome]);
+
+  // PBT control total: prefer the reported pre-tax income; else net income + tax.
+  let pbt = num(v.pretaxIncome);
+  if (pbt == null && num(v.netIncome) != null && num(v.incomeTaxExpense) != null) {
+    pbt = v.netIncome + v.incomeTaxExpense;
+  }
+
+  const totalExpenses = totalIncome != null && pbt != null ? totalIncome - pbt : null;
+  const costOfRevenue = num(v.costOfRevenue);
+  const financeCosts = num(v.interestExpense);
+  const otherExpenses =
+    totalExpenses != null ? totalExpenses - (addable([costOfRevenue, financeCosts]) || 0) : null;
+
+  const totalTax = num(v.incomeTaxExpense);
+  const deferredTax = num(v.deferredIncomeTaxes);
+  const currentTax = totalTax != null ? totalTax - (deferredTax || 0) : null;
+
+  const profitAfterTax = pbt != null && totalTax != null ? pbt - totalTax : null;
+  const netIncome = num(v.netIncome);
+  // Plug for minority interest / discontinued ops so PAT + this = net income.
+  const otherItems = netIncome != null && profitAfterTax != null ? netIncome - profitAfterTax : null;
+
+  const epsBasic = num(v.epsBasic);
+  const epsDiluted = num(v.dilutedEPS);
+
+  const difference =
+    totalIncome != null && totalExpenses != null && pbt != null
+      ? totalIncome - totalExpenses - pbt
+      : null;
+  const balances = difference == null ? null : Math.abs(difference) <= 1;
+
+  const L = (key, label, kind, level, value, unit = 'USD') => ({ key, label, kind, level, value, unit });
+
+  const lines = [
+    L('rev', 'I. Revenue from operations', 'item', 1, revenue),
+    L('oi', 'II. Other income', 'item', 1, otherIncome),
+    L('ti', 'III. Total Income (I + II)', 'subtotal', 0, totalIncome),
+    L('exp', 'IV. Expenses', 'header', 1, null),
+    L('cor', 'Cost of revenue / materials & services', 'item', 2, costOfRevenue),
+    L('fc', 'Finance costs', 'item', 2, financeCosts),
+    L('oe', 'Other expenses (operating & unmapped)', 'item', 2, otherExpenses),
+    L('te', 'Total Expenses', 'subtotal', 1, totalExpenses),
+    L('pbt', 'V. Profit Before Tax (III − IV)', 'subtotal', 0, pbt),
+    L('tax', 'VI. Tax expense', 'header', 1, null),
+    L('ct', '(1) Current tax', 'item', 2, currentTax),
+    L('dt', '(2) Deferred tax', 'item', 2, deferredTax),
+    L('tt', 'Total tax expense', 'subtotal', 1, totalTax),
+    L('pat', 'VII. Profit After Tax (V − VI)', 'subtotal', 0, profitAfterTax),
+    L('oth', 'VIII. Other items (NCI, discontinued ops)', 'item', 1, otherItems),
+    L('pfp', 'IX. Profit for the period', 'grandtotal', 0, netIncome),
+    L('eps', 'X. Earnings per equity share', 'header', 1, null),
+    L('epsb', '(1) Basic', 'item', 2, epsBasic, 'USD/shares'),
+    L('epsd', '(2) Diluted', 'item', 2, epsDiluted, 'USD/shares'),
+  ];
+
+  return { fiscalYear: v.fiscalYear, lines, difference, balances };
+}
+
+module.exports = { buildScheduleIIIPL: computeScheduleIIIPL };

--- a/server/src/marketData.js
+++ b/server/src/marketData.js
@@ -1,0 +1,48 @@
+const config = require('./config');
+
+// Pluggable market-data provider for the inputs SEC does not have (beta and
+// market capitalisation). Default provider: Alpha Vantage (free API key).
+//
+// The OVERVIEW endpoint returns Beta and MarketCapitalization directly:
+//   https://www.alphavantage.co/query?function=OVERVIEW&symbol=NFLX&apikey=KEY
+function createMarketDataProvider({ client, apiKey = config.alphaVantageApiKey, baseUrl = config.alphaVantageBaseUrl } = {}) {
+  const configured = Boolean(apiKey);
+
+  async function getOverview(ticker) {
+    if (!configured) {
+      return { configured: false, beta: null, marketCap: null, source: 'none' };
+    }
+    const url =
+      `${baseUrl}/query?function=OVERVIEW&symbol=${encodeURIComponent(ticker)}` +
+      `&apikey=${encodeURIComponent(apiKey)}`;
+    const data = await client.getJson(url);
+
+    // Alpha Vantage signals throttling/errors with a Note/Information field and
+    // an otherwise empty object.
+    if (!data || data.Note || data.Information || Object.keys(data).length === 0) {
+      const reason = (data && (data.Note || data.Information)) || 'no data returned';
+      const err = new Error(`Market-data provider error: ${reason}`);
+      err.status = 502;
+      throw err;
+    }
+
+    const beta = data.Beta != null && data.Beta !== 'None' ? Number(data.Beta) : null;
+    const marketCap =
+      data.MarketCapitalization != null && data.MarketCapitalization !== 'None'
+        ? Number(data.MarketCapitalization)
+        : null;
+
+    return {
+      configured: true,
+      provider: config.marketDataProvider,
+      beta: Number.isFinite(beta) ? beta : null,
+      marketCap: Number.isFinite(marketCap) ? marketCap : null,
+      name: data.Name || null,
+      source: `${config.marketDataProvider}:OVERVIEW`,
+    };
+  }
+
+  return { configured, getOverview };
+}
+
+module.exports = { createMarketDataProvider };

--- a/server/src/normalize.js
+++ b/server/src/normalize.js
@@ -40,16 +40,20 @@ function selectUnit(tagData, preferredUnit) {
 
 // Prefer the entry whose report fiscal year equals the period year (the
 // original 10-K for that year); otherwise prefer the most recently filed.
-function isBetterCandidate(candidate, existing, fiscalYear) {
+function isBetterCandidate(candidate, existing, fiscalYear, preferLatest = false) {
+  const newer = Date.parse(candidate.filed || 0) > Date.parse(existing.filed || 0);
+  // For split-sensitive fields (EPS, shares) prefer the most recently filed
+  // value so the series is restated/split-adjusted.
+  if (preferLatest) return newer;
   const candIsOriginal = candidate.reportFiscalYear === fiscalYear;
   const existIsOriginal = existing.reportFiscalYear === fiscalYear;
   if (candIsOriginal !== existIsOriginal) return candIsOriginal;
-  return Date.parse(candidate.filed || 0) > Date.parse(existing.filed || 0);
+  return newer;
 }
 
 // Map fiscalYear -> audited value for a single XBRL tag, keeping only annual
 // 10-K facts (form === "10-K", fp === "FY").
-function selectAnnualByYear(tagData, preferredUnit) {
+function selectAnnualByYear(tagData, preferredUnit, preferLatest = false) {
   const { unit, entries } = selectUnit(tagData, preferredUnit);
   const byYear = new Map();
   for (const entry of entries) {
@@ -71,7 +75,7 @@ function selectAnnualByYear(tagData, preferredUnit) {
       periodStart: entry.start || null,
     };
     const existing = byYear.get(fiscalYear);
-    if (!existing || isBetterCandidate(candidate, existing, fiscalYear)) {
+    if (!existing || isBetterCandidate(candidate, existing, fiscalYear, preferLatest)) {
       byYear.set(fiscalYear, candidate);
     }
   }
@@ -87,10 +91,11 @@ function buildFieldSeries(companyFacts, field) {
   for (const tag of def.tags) {
     const tagData = gaap[tag];
     if (!tagData) continue;
-    const series = selectAnnualByYear(tagData, def.unit);
+    const series = selectAnnualByYear(tagData, def.unit, def.preferLatestFiling);
     for (const [fiscalYear, audited] of series) {
       if (!byYear.has(fiscalYear)) {
-        byYear.set(fiscalYear, { ...audited, tag });
+        const value = def.negate ? -Math.abs(audited.value) : audited.value;
+        byYear.set(fiscalYear, { ...audited, value, tag });
       }
     }
   }
@@ -175,6 +180,53 @@ function buildPeriod(fiscalYear, fieldSeries) {
   return period;
 }
 
+// Derive gross profit (revenue - cost of revenue) for years the company did not
+// tag GrossProfit directly.
+function applyGrossProfitFallback(fieldSeries) {
+  const revenue = fieldSeries.revenue;
+  const cost = fieldSeries.costOfRevenue;
+  const gross = fieldSeries.grossProfit;
+  for (const [fiscalYear, rev] of revenue) {
+    if (gross.has(fiscalYear)) continue;
+    const c = cost.get(fiscalYear);
+    if (!c) continue;
+    gross.set(fiscalYear, {
+      value: rev.value - c.value,
+      unit: rev.unit,
+      fiscalYear,
+      reportFiscalYear: rev.reportFiscalYear,
+      accessionNumber: rev.accessionNumber,
+      filed: rev.filed,
+      form: rev.form,
+      periodEnd: rev.periodEnd,
+      tag: `${rev.tag} − ${c.tag}`,
+      derived: true,
+    });
+  }
+}
+
+// Flag a likely stock split where weighted diluted shares jump by >3x (or <1/3x)
+// between adjacent years — the per-share series may not be split-consistent
+// across that boundary (older filings are not restated in available data).
+function detectSplitWarnings(fieldSeries, sortedYears) {
+  const shares = fieldSeries.dilutedShares;
+  const warnings = [];
+  for (let i = 0; i < sortedYears.length - 1; i += 1) {
+    const newer = shares.get(sortedYears[i]);
+    const older = shares.get(sortedYears[i + 1]);
+    if (!newer || !older || !older.value) continue;
+    const ratio = newer.value / older.value;
+    if (ratio >= 3 || ratio <= 1 / 3) {
+      warnings.push(
+        `Diluted shares change ~${ratio.toFixed(1)}x between FY${sortedYears[i + 1]} and ` +
+          `FY${sortedYears[i]} — likely a stock split. Per-share figures may not be ` +
+          `split-consistent across that boundary (older filings aren't restated in SEC data).`
+      );
+    }
+  }
+  return warnings;
+}
+
 // Turn raw SEC companyfacts JSON into normalized, modelling-ready annual data.
 function normalizeCompanyFacts(companyFacts, { years } = {}) {
   const fieldSeries = {};
@@ -182,6 +234,7 @@ function normalizeCompanyFacts(companyFacts, { years } = {}) {
     fieldSeries[field] = buildFieldSeries(companyFacts, field);
   }
   applyLiabilitiesFallback(companyFacts, fieldSeries.totalLiabilities);
+  applyGrossProfitFallback(fieldSeries);
 
   const yearSet = new Set();
   for (const field of FIELDS) {
@@ -199,6 +252,7 @@ function normalizeCompanyFacts(companyFacts, { years } = {}) {
   return {
     cik: null, // filled in by the service (padded form)
     companyName: companyFacts && companyFacts.entityName ? companyFacts.entityName : null,
+    warnings: detectSplitWarnings(fieldSeries, sortedYears),
     periods: sortedYears.map((fiscalYear) => buildPeriod(fiscalYear, fieldSeries)),
   };
 }

--- a/server/src/normalize.js
+++ b/server/src/normalize.js
@@ -1,0 +1,212 @@
+const TAG_MAP = require('./tagMap');
+
+// Field order and the period-level fields that are good "anchors" for choosing
+// a representative accession number / filed date for each period.
+const FIELDS = Object.keys(TAG_MAP);
+const ANCHOR_PRIORITY = ['netIncome', 'revenue', 'totalAssets', 'stockholdersEquity'];
+
+function yearOf(dateStr) {
+  const year = Number(String(dateStr || '').slice(0, 4));
+  return Number.isFinite(year) && year > 0 ? year : null;
+}
+
+// Duration facts (income statement, cash flow) have a `start`. We only keep
+// full-year periods (~365 days) so quarterly/partial durations are excluded.
+function isFullYearDuration(entry) {
+  if (!entry.start || !entry.end) return false;
+  const start = Date.parse(entry.start);
+  const end = Date.parse(entry.end);
+  if (Number.isNaN(start) || Number.isNaN(end)) return false;
+  const days = (end - start) / (1000 * 60 * 60 * 24);
+  return days >= 350 && days <= 380;
+}
+
+function getGaapFacts(companyFacts) {
+  return (companyFacts && companyFacts.facts && companyFacts.facts['us-gaap']) || {};
+}
+
+// Pick the preferred unit if present, otherwise the first reported unit. The
+// chosen unit name is returned so it can be recorded for auditability.
+function selectUnit(tagData, preferredUnit) {
+  const units = tagData && tagData.units;
+  if (!units) return { unit: null, entries: [] };
+  if (Array.isArray(units[preferredUnit])) {
+    return { unit: preferredUnit, entries: units[preferredUnit] };
+  }
+  const keys = Object.keys(units);
+  if (keys.length === 0) return { unit: null, entries: [] };
+  return { unit: keys[0], entries: units[keys[0]] };
+}
+
+// Prefer the entry whose report fiscal year equals the period year (the
+// original 10-K for that year); otherwise prefer the most recently filed.
+function isBetterCandidate(candidate, existing, fiscalYear) {
+  const candIsOriginal = candidate.reportFiscalYear === fiscalYear;
+  const existIsOriginal = existing.reportFiscalYear === fiscalYear;
+  if (candIsOriginal !== existIsOriginal) return candIsOriginal;
+  return Date.parse(candidate.filed || 0) > Date.parse(existing.filed || 0);
+}
+
+// Map fiscalYear -> audited value for a single XBRL tag, keeping only annual
+// 10-K facts (form === "10-K", fp === "FY").
+function selectAnnualByYear(tagData, preferredUnit) {
+  const { unit, entries } = selectUnit(tagData, preferredUnit);
+  const byYear = new Map();
+  for (const entry of entries) {
+    if (entry.form !== '10-K' || entry.fp !== 'FY') continue;
+    const isInstant = !entry.start;
+    if (!isInstant && !isFullYearDuration(entry)) continue;
+    const fiscalYear = yearOf(entry.end);
+    if (!fiscalYear) continue;
+
+    const candidate = {
+      value: entry.val,
+      unit,
+      fiscalYear,
+      reportFiscalYear: entry.fy,
+      accessionNumber: entry.accn || null,
+      filed: entry.filed || null,
+      form: entry.form,
+      periodEnd: entry.end,
+      periodStart: entry.start || null,
+    };
+    const existing = byYear.get(fiscalYear);
+    if (!existing || isBetterCandidate(candidate, existing, fiscalYear)) {
+      byYear.set(fiscalYear, candidate);
+    }
+  }
+  return byYear;
+}
+
+// Build fiscalYear -> audited value for a modelling field, walking its tag list
+// in priority order. The first tag that has a value for a year fills that year.
+function buildFieldSeries(companyFacts, field) {
+  const gaap = getGaapFacts(companyFacts);
+  const def = TAG_MAP[field];
+  const byYear = new Map();
+  for (const tag of def.tags) {
+    const tagData = gaap[tag];
+    if (!tagData) continue;
+    const series = selectAnnualByYear(tagData, def.unit);
+    for (const [fiscalYear, audited] of series) {
+      if (!byYear.has(fiscalYear)) {
+        byYear.set(fiscalYear, { ...audited, tag });
+      }
+    }
+  }
+  return byYear;
+}
+
+// Fallback for total liabilities: LiabilitiesCurrent + LiabilitiesNoncurrent,
+// applied only for years where the direct `Liabilities` tag is missing.
+function applyLiabilitiesFallback(companyFacts, totalLiabilitiesSeries) {
+  const gaap = getGaapFacts(companyFacts);
+  const current = selectAnnualByYear(gaap.LiabilitiesCurrent, 'USD');
+  const noncurrent = selectAnnualByYear(gaap.LiabilitiesNoncurrent, 'USD');
+  for (const [fiscalYear, cur] of current) {
+    if (totalLiabilitiesSeries.has(fiscalYear)) continue;
+    const non = noncurrent.get(fiscalYear);
+    if (!non) continue;
+    totalLiabilitiesSeries.set(fiscalYear, {
+      value: cur.value + non.value,
+      unit: cur.unit,
+      fiscalYear,
+      reportFiscalYear: cur.reportFiscalYear,
+      accessionNumber: cur.accessionNumber,
+      filed: cur.filed,
+      form: cur.form,
+      periodEnd: cur.periodEnd,
+      periodStart: null,
+      tag: 'LiabilitiesCurrent+LiabilitiesNoncurrent',
+      derived: true,
+    });
+  }
+}
+
+function buildPeriod(fiscalYear, fieldSeries) {
+  const period = {
+    fiscalYear,
+    form: '10-K',
+    filed: null,
+    accessionNumber: null,
+  };
+  const rawTagsUsed = {};
+  const present = [];
+
+  for (const field of FIELDS) {
+    const audited = fieldSeries[field].get(fiscalYear);
+    if (!audited) {
+      period[field] = null;
+      continue;
+    }
+    period[field] = audited.value;
+    rawTagsUsed[field] = {
+      tag: audited.tag,
+      unit: audited.unit,
+      value: audited.value,
+      fiscalYear: audited.fiscalYear,
+      reportFiscalYear: audited.reportFiscalYear,
+      accessionNumber: audited.accessionNumber,
+      filed: audited.filed,
+      form: audited.form,
+      periodEnd: audited.periodEnd,
+      ...(audited.derived ? { derived: true } : {}),
+    };
+    present.push({ field, audited });
+  }
+
+  // Period-level filed/accession: prefer original-year filings, then latest filed.
+  const originals = present.filter((p) => p.audited.reportFiscalYear === fiscalYear);
+  const pool = originals.length ? originals : present;
+  pool.sort((a, b) => {
+    const ap = ANCHOR_PRIORITY.indexOf(a.field);
+    const bp = ANCHOR_PRIORITY.indexOf(b.field);
+    const aRank = ap === -1 ? Number.MAX_SAFE_INTEGER : ap;
+    const bRank = bp === -1 ? Number.MAX_SAFE_INTEGER : bp;
+    if (aRank !== bRank) return aRank - bRank;
+    return Date.parse(b.audited.filed || 0) - Date.parse(a.audited.filed || 0);
+  });
+  if (pool.length) {
+    period.filed = pool[0].audited.filed;
+    period.accessionNumber = pool[0].audited.accessionNumber;
+  }
+
+  period.rawTagsUsed = rawTagsUsed;
+  return period;
+}
+
+// Turn raw SEC companyfacts JSON into normalized, modelling-ready annual data.
+function normalizeCompanyFacts(companyFacts, { years } = {}) {
+  const fieldSeries = {};
+  for (const field of FIELDS) {
+    fieldSeries[field] = buildFieldSeries(companyFacts, field);
+  }
+  applyLiabilitiesFallback(companyFacts, fieldSeries.totalLiabilities);
+
+  const yearSet = new Set();
+  for (const field of FIELDS) {
+    for (const fiscalYear of fieldSeries[field].keys()) {
+      yearSet.add(fiscalYear);
+    }
+  }
+
+  let sortedYears = [...yearSet].sort((a, b) => b - a);
+  const limit = Number(years);
+  if (Number.isFinite(limit) && limit > 0) {
+    sortedYears = sortedYears.slice(0, limit);
+  }
+
+  return {
+    cik: null, // filled in by the service (padded form)
+    companyName: companyFacts && companyFacts.entityName ? companyFacts.entityName : null,
+    periods: sortedYears.map((fiscalYear) => buildPeriod(fiscalYear, fieldSeries)),
+  };
+}
+
+module.exports = {
+  normalizeCompanyFacts,
+  // exported for unit testing
+  selectAnnualByYear,
+  isFullYearDuration,
+  buildFieldSeries,
+};

--- a/server/src/normalize.js
+++ b/server/src/normalize.js
@@ -203,8 +203,60 @@ function normalizeCompanyFacts(companyFacts, { years } = {}) {
   };
 }
 
+// Extract EVERY us-gaap concept that has annual 10-K / FY values, as a
+// normalized time series. This is the "fetch everything" path — it surfaces all
+// line items the company reported in XBRL, using the raw tag names.
+function extractAllAnnualFacts(companyFacts, { years } = {}) {
+  const gaap = getGaapFacts(companyFacts);
+  const yearSet = new Set();
+  let concepts = [];
+
+  for (const [tag, tagData] of Object.entries(gaap)) {
+    const byYear = selectAnnualByYear(tagData, 'USD');
+    if (byYear.size === 0) continue;
+    const values = {};
+    let unit = null;
+    for (const [fiscalYear, audited] of byYear) {
+      unit = audited.unit;
+      values[fiscalYear] = {
+        value: audited.value,
+        unit: audited.unit,
+        accessionNumber: audited.accessionNumber,
+        filed: audited.filed,
+        form: audited.form,
+        periodEnd: audited.periodEnd,
+      };
+      yearSet.add(fiscalYear);
+    }
+    concepts.push({ tag, label: tagData.label || tag, unit, values });
+  }
+
+  let fiscalYears = [...yearSet].sort((a, b) => b - a);
+  const limit = Number(years);
+  if (Number.isFinite(limit) && limit > 0) {
+    fiscalYears = fiscalYears.slice(0, limit);
+    const keep = new Set(fiscalYears);
+    for (const concept of concepts) {
+      for (const fy of Object.keys(concept.values)) {
+        if (!keep.has(Number(fy))) delete concept.values[fy];
+      }
+    }
+    concepts = concepts.filter((c) => Object.keys(c.values).length > 0);
+  }
+
+  concepts.sort((a, b) => a.tag.localeCompare(b.tag));
+
+  return {
+    taxonomy: 'us-gaap',
+    fiscalYears,
+    conceptCount: concepts.length,
+    concepts,
+  };
+}
+
 module.exports = {
   normalizeCompanyFacts,
+  extractAllAnnualFacts,
   // exported for unit testing
   selectAnnualByYear,
   isFullYearDuration,

--- a/server/src/priceData.js
+++ b/server/src/priceData.js
@@ -4,6 +4,9 @@
 //
 // Stooq CSV: https://stooq.com/q/l/?s=aapl.us&f=sd2t2ohlcv&h&e=csv
 //   Symbol,Date,Time,Open,High,Low,Close,Volume
+//
+// Stooq can reject unusual User-Agents, so we request it directly with a
+// browser-like UA rather than via the SEC client (which sends the SEC UA).
 
 function parseStooqCsv(csv) {
   if (!csv || typeof csv !== 'string') return null;
@@ -17,11 +20,25 @@ function parseStooqCsv(csv) {
   return Number.isFinite(close) && close > 0 ? close : null;
 }
 
-function createPriceProvider({ client, baseUrl = 'https://stooq.com' } = {}) {
+function createPriceProvider({ client, fetchImpl = globalThis.fetch, baseUrl = 'https://stooq.com' } = {}) {
   async function getClose(ticker) {
     const sym = encodeURIComponent(String(ticker).toLowerCase()) + '.us';
     const url = `${baseUrl}/q/l/?s=${sym}&f=sd2t2ohlcv&h&e=csv`;
-    const csv = await client.getText(url);
+    let csv;
+    if (typeof fetchImpl === 'function') {
+      const res = await fetchImpl(url, {
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (compatible; FinancialModellingEducationApp/1.0)',
+          Accept: 'text/csv,text/plain,*/*',
+        },
+      });
+      if (!res.ok) return null;
+      csv = await res.text();
+    } else if (client && client.getText) {
+      csv = await client.getText(url);
+    } else {
+      return null;
+    }
     return parseStooqCsv(csv);
   }
   return { getClose, source: 'stooq' };

--- a/server/src/priceData.js
+++ b/server/src/priceData.js
@@ -1,0 +1,30 @@
+// Free, no-key latest share price from Stooq (used to derive market cap when no
+// market-data API key is configured). Market cap = latest close × shares
+// outstanding (the latter from SEC dei data).
+//
+// Stooq CSV: https://stooq.com/q/l/?s=aapl.us&f=sd2t2ohlcv&h&e=csv
+//   Symbol,Date,Time,Open,High,Low,Close,Volume
+
+function parseStooqCsv(csv) {
+  if (!csv || typeof csv !== 'string') return null;
+  const lines = csv.trim().split(/\r?\n/);
+  if (lines.length < 2) return null;
+  const header = lines[0].split(',').map((s) => s.trim().toLowerCase());
+  const row = lines[1].split(',');
+  const idx = header.indexOf('close');
+  if (idx === -1) return null;
+  const close = Number(row[idx]);
+  return Number.isFinite(close) && close > 0 ? close : null;
+}
+
+function createPriceProvider({ client, baseUrl = 'https://stooq.com' } = {}) {
+  async function getClose(ticker) {
+    const sym = encodeURIComponent(String(ticker).toLowerCase()) + '.us';
+    const url = `${baseUrl}/q/l/?s=${sym}&f=sd2t2ohlcv&h&e=csv`;
+    const csv = await client.getText(url);
+    return parseStooqCsv(csv);
+  }
+  return { getClose, source: 'stooq' };
+}
+
+module.exports = { createPriceProvider, parseStooqCsv };

--- a/server/src/profile.js
+++ b/server/src/profile.js
@@ -1,0 +1,120 @@
+// Builds a student-facing company profile from SEC submissions metadata plus a
+// financial snapshot computed from the normalized model data. No data beyond
+// what SEC already provides.
+
+function pct(numerator, denominator) {
+  if (numerator == null || !denominator) return null;
+  return numerator / denominator;
+}
+
+function fmtBillions(v) {
+  if (v == null) return 'n/a';
+  const sign = v < 0 ? '-' : '';
+  const a = Math.abs(v);
+  if (a >= 1e9) return `${sign}$${(a / 1e9).toFixed(1)}B`;
+  if (a >= 1e6) return `${sign}$${(a / 1e6).toFixed(0)}M`;
+  return `${sign}$${a}`;
+}
+
+function fmtPct(v) {
+  return v == null ? 'n/a' : `${(v * 100).toFixed(1)}%`;
+}
+
+// Per-period financial highlights from the normalized periods (newest first).
+function buildSnapshot(periods) {
+  if (!periods || !periods.length) return null;
+  const latest = periods[0];
+  const prior = periods[1] || null;
+
+  const totalDebt =
+    (latest.shortTermDebt || 0) + (latest.longTermDebt || 0) || null;
+
+  return {
+    fiscalYear: latest.fiscalYear,
+    revenue: latest.revenue,
+    revenueGrowth: prior ? pct((latest.revenue || 0) - (prior.revenue || 0), prior.revenue) : null,
+    grossMargin: pct(latest.grossProfit, latest.revenue),
+    operatingMargin: pct(latest.operatingIncome, latest.revenue),
+    netMargin: pct(latest.netIncome, latest.revenue),
+    netIncome: latest.netIncome,
+    totalAssets: latest.totalAssets,
+    totalLiabilities: latest.totalLiabilities,
+    stockholdersEquity: latest.stockholdersEquity,
+    returnOnAssets: pct(latest.netIncome, latest.totalAssets),
+    returnOnEquity: pct(latest.netIncome, latest.stockholdersEquity),
+    currentRatio: pct(latest.currentAssets, latest.currentLiabilities),
+    debtToEquity: pct(totalDebt, latest.stockholdersEquity),
+    totalDebt,
+  };
+}
+
+function buildNarrative(name, submissions, snapshot) {
+  const industry = submissions.sicDescription || 'company';
+  const state = submissions.stateOfIncorporation || submissions.addresses?.business?.stateOrCountry;
+  const parts = [];
+  parts.push(
+    `${name} operates in ${industry}${state ? ` and is incorporated in ${state}` : ''}.`
+  );
+  if (snapshot) {
+    const growth =
+      snapshot.revenueGrowth == null
+        ? ''
+        : `, ${snapshot.revenueGrowth >= 0 ? 'up' : 'down'} ${fmtPct(Math.abs(snapshot.revenueGrowth))} year over year`;
+    parts.push(
+      `In FY${snapshot.fiscalYear} it reported revenue of ${fmtBillions(snapshot.revenue)}${growth}, ` +
+        `a net margin of ${fmtPct(snapshot.netMargin)} and return on equity of ${fmtPct(snapshot.returnOnEquity)}.`
+    );
+  }
+  return parts.join(' ');
+}
+
+function recentAnnualFilings(submissions, limit = 5) {
+  const recent = submissions.filings && submissions.filings.recent;
+  if (!recent || !Array.isArray(recent.form)) return [];
+  const out = [];
+  for (let i = 0; i < recent.form.length && out.length < limit; i += 1) {
+    if (recent.form[i] !== '10-K') continue;
+    out.push({
+      form: recent.form[i],
+      filed: recent.filingDate ? recent.filingDate[i] : null,
+      accessionNumber: recent.accessionNumber ? recent.accessionNumber[i] : null,
+      reportDate: recent.reportDate ? recent.reportDate[i] : null,
+      primaryDocument: recent.primaryDocument ? recent.primaryDocument[i] : null,
+    });
+  }
+  return out;
+}
+
+function buildProfile({ ticker, cik, submissions, modelData }) {
+  const name = submissions.name || (modelData && modelData.companyName) || ticker;
+  const snapshot = buildSnapshot(modelData && modelData.periods);
+  const business = submissions.addresses && submissions.addresses.business;
+
+  return {
+    ticker,
+    cik,
+    name,
+    formerNames: (submissions.formerNames || []).map((f) => f.name),
+    exchanges: submissions.exchanges || [],
+    tickers: submissions.tickers || [ticker],
+    sicCode: submissions.sic || null,
+    industry: submissions.sicDescription || null,
+    category: submissions.category || null,
+    stateOfIncorporation: submissions.stateOfIncorporation || null,
+    fiscalYearEnd: submissions.fiscalYearEnd || null,
+    website: submissions.website || null,
+    headquarters: business
+      ? {
+          city: business.city || null,
+          state: business.stateOrCountry || null,
+          street: [business.street1, business.street2].filter(Boolean).join(', ') || null,
+        }
+      : null,
+    employees: submissions.employees || null,
+    snapshot,
+    narrative: buildNarrative(name, submissions, snapshot),
+    recentFilings: recentAnnualFilings(submissions),
+  };
+}
+
+module.exports = { buildProfile, buildSnapshot };

--- a/server/src/profile.js
+++ b/server/src/profile.js
@@ -28,6 +28,10 @@ function buildSnapshot(periods) {
 
   const totalDebt =
     (latest.shortTermDebt || 0) + (latest.longTermDebt || 0) || null;
+  const freeCashFlow =
+    latest.operatingCashFlow != null && latest.capitalExpenditure != null
+      ? latest.operatingCashFlow - latest.capitalExpenditure
+      : null;
 
   return {
     fiscalYear: latest.fiscalYear,
@@ -37,6 +41,8 @@ function buildSnapshot(periods) {
     operatingMargin: pct(latest.operatingIncome, latest.revenue),
     netMargin: pct(latest.netIncome, latest.revenue),
     netIncome: latest.netIncome,
+    operatingCashFlow: latest.operatingCashFlow,
+    freeCashFlow,
     totalAssets: latest.totalAssets,
     totalLiabilities: latest.totalLiabilities,
     stockholdersEquity: latest.stockholdersEquity,

--- a/server/src/ratios.js
+++ b/server/src/ratios.js
@@ -1,0 +1,53 @@
+// Working-capital and liquidity ratios derived from the normalized periods.
+// Pure computation — no external data.
+
+const div = (a, b) => (a == null || b == null || b === 0 ? null : a / b);
+
+// Days ratios use the absolute value of COGS, which SEC may report as a
+// positive expense.
+const daysOf = (balance, flow) => {
+  if (balance == null || flow == null || flow === 0) return null;
+  return (balance / Math.abs(flow)) * 365;
+};
+
+function ratiosForPeriod(p) {
+  const totalDebt = (p.shortTermDebt || 0) + (p.longTermDebt || 0) || null;
+  const dso = daysOf(p.accountsReceivable, p.revenue);
+  const dpo = daysOf(p.accountsPayable, p.costOfRevenue);
+  const dio = daysOf(p.inventory, p.costOfRevenue);
+  const ccc =
+    dso == null && dio == null && dpo == null ? null : (dso || 0) + (dio || 0) - (dpo || 0);
+
+  return {
+    fiscalYear: p.fiscalYear,
+    // liquidity
+    currentRatio: div(p.currentAssets, p.currentLiabilities),
+    quickRatio: div(
+      p.currentAssets != null ? p.currentAssets - (p.inventory || 0) : null,
+      p.currentLiabilities
+    ),
+    workingCapital:
+      p.currentAssets != null && p.currentLiabilities != null
+        ? p.currentAssets - p.currentLiabilities
+        : null,
+    // working-capital efficiency (days)
+    daysSalesOutstanding: dso,
+    daysPayablesOutstanding: dpo,
+    daysInventoryOutstanding: dio,
+    cashConversionCycle: ccc,
+    // leverage
+    debtToEquity: div(totalDebt, p.stockholdersEquity),
+    debtToAssets: div(totalDebt, p.totalAssets),
+    interestCoverage: div(p.operatingIncome, p.interestExpense),
+    // returns
+    netMargin: div(p.netIncome, p.revenue),
+    returnOnEquity: div(p.netIncome, p.stockholdersEquity),
+    returnOnAssets: div(p.netIncome, p.totalAssets),
+  };
+}
+
+function computeRatios(periods) {
+  return (periods || []).map(ratiosForPeriod);
+}
+
+module.exports = { computeRatios, ratiosForPeriod };

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -1,0 +1,44 @@
+const express = require('express');
+
+// Wraps async route handlers so rejected promises reach the error middleware.
+const asyncHandler = (fn) => (req, res, next) => Promise.resolve(fn(req, res, next)).catch(next);
+
+function createRouter({ service }) {
+  const router = express.Router();
+
+  router.get('/health', (req, res) => {
+    res.json({ status: 'ok' });
+  });
+
+  router.get(
+    '/company',
+    asyncHandler(async (req, res) => {
+      res.json(await service.getCompany(req.query.ticker));
+    })
+  );
+
+  router.get(
+    '/companyfacts',
+    asyncHandler(async (req, res) => {
+      res.json(await service.getCompanyFacts(req.query.ticker));
+    })
+  );
+
+  router.get(
+    '/model-data',
+    asyncHandler(async (req, res) => {
+      res.json(await service.getModelData(req.query.ticker, { years: req.query.years }));
+    })
+  );
+
+  router.get(
+    '/concept',
+    asyncHandler(async (req, res) => {
+      res.json(await service.getConcept(req.query.ticker, req.query.tag, req.query.taxonomy));
+    })
+  );
+
+  return router;
+}
+
+module.exports = { createRouter, asyncHandler };

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -32,6 +32,46 @@ function createRouter({ service }) {
   );
 
   router.get(
+    '/profile',
+    asyncHandler(async (req, res) => {
+      res.json(await service.getProfile(req.query.ticker));
+    })
+  );
+
+  router.get(
+    '/ratios',
+    asyncHandler(async (req, res) => {
+      res.json(await service.getRatios(req.query.ticker, { years: req.query.years }));
+    })
+  );
+
+  router.get(
+    '/wacc',
+    asyncHandler(async (req, res) => {
+      const q = req.query;
+      const overrides = {};
+      // Accept student overrides; ignore blanks/non-numerics.
+      const map = {
+        beta: 'beta',
+        rf: 'riskFreeRate',
+        riskFreeRate: 'riskFreeRate',
+        erp: 'equityRiskPremium',
+        equityRiskPremium: 'equityRiskPremium',
+        marketCap: 'marketCap',
+        costOfDebt: 'costOfDebt',
+        taxRate: 'taxRate',
+        totalDebt: 'totalDebt',
+      };
+      for (const [param, key] of Object.entries(map)) {
+        if (q[param] !== undefined && q[param] !== '' && Number.isFinite(Number(q[param]))) {
+          overrides[key] = Number(q[param]);
+        }
+      }
+      res.json(await service.getWacc(q.ticker, overrides));
+    })
+  );
+
+  router.get(
     '/all-facts',
     asyncHandler(async (req, res) => {
       res.json(await service.getAllFacts(req.query.ticker, { years: req.query.years }));

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -46,6 +46,13 @@ function createRouter({ service }) {
   );
 
   router.get(
+    '/balance-sheet',
+    asyncHandler(async (req, res) => {
+      res.json(await service.getBalanceSheet(req.query.ticker, { years: req.query.years }));
+    })
+  );
+
+  router.get(
     '/ratios',
     asyncHandler(async (req, res) => {
       res.json(await service.getRatios(req.query.ticker, { years: req.query.years }));

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -32,6 +32,17 @@ function createRouter({ service }) {
   );
 
   router.get(
+    '/all-facts',
+    asyncHandler(async (req, res) => {
+      res.json(await service.getAllFacts(req.query.ticker, { years: req.query.years }));
+    })
+  );
+
+  router.get('/fields', (req, res) => {
+    res.json(service.getFields());
+  });
+
+  router.get(
     '/concept',
     asyncHandler(async (req, res) => {
       res.json(await service.getConcept(req.query.ticker, req.query.tag, req.query.taxonomy));

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -46,6 +46,13 @@ function createRouter({ service }) {
   );
 
   router.get(
+    '/income-statement',
+    asyncHandler(async (req, res) => {
+      res.json(await service.getIncomeStatement(req.query.ticker, { years: req.query.years }));
+    })
+  );
+
+  router.get(
     '/balance-sheet',
     asyncHandler(async (req, res) => {
       res.json(await service.getBalanceSheet(req.query.ticker, { years: req.query.years }));

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -88,7 +88,12 @@ function createRouter({ service }) {
   router.get(
     '/segments',
     asyncHandler(async (req, res) => {
-      res.json(await service.getSegments(req.query.ticker, { filings: req.query.filings }));
+      res.json(
+        await service.getSegments(req.query.ticker, {
+          filings: req.query.filings,
+          years: req.query.years,
+        })
+      );
     })
   );
 

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -39,6 +39,13 @@ function createRouter({ service }) {
   );
 
   router.get(
+    '/business',
+    asyncHandler(async (req, res) => {
+      res.json(await service.getBusinessSummary(req.query.ticker));
+    })
+  );
+
+  router.get(
     '/ratios',
     asyncHandler(async (req, res) => {
       res.json(await service.getRatios(req.query.ticker, { years: req.query.years }));

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -81,7 +81,7 @@ function createRouter({ service }) {
   router.get(
     '/segments',
     asyncHandler(async (req, res) => {
-      res.json(await service.getSegments(req.query.ticker));
+      res.json(await service.getSegments(req.query.ticker, { filings: req.query.filings }));
     })
   );
 

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -72,6 +72,13 @@ function createRouter({ service }) {
   );
 
   router.get(
+    '/segments',
+    asyncHandler(async (req, res) => {
+      res.json(await service.getSegments(req.query.ticker));
+    })
+  );
+
+  router.get(
     '/all-facts',
     asyncHandler(async (req, res) => {
       res.json(await service.getAllFacts(req.query.ticker, { years: req.query.years }));

--- a/server/src/secClient.js
+++ b/server/src/secClient.js
@@ -61,8 +61,9 @@ function createSecClient(options = {}) {
     return baseBackoffMs * 2 ** attempt;
   }
 
-  async function getJson(url) {
-    const cached = cache.get(url);
+  async function request(url, parse, cacheKey) {
+    const key = cacheKey || url;
+    const cached = cache.get(key);
     if (cached !== undefined) {
       return cached;
     }
@@ -81,8 +82,8 @@ function createSecClient(options = {}) {
       }
 
       if (response.ok) {
-        const data = await response.json();
-        cache.set(url, data);
+        const data = await parse(response);
+        cache.set(key, data);
         return data;
       }
 
@@ -94,14 +95,17 @@ function createSecClient(options = {}) {
       }
 
       const err = new Error(
-        `SEC request failed: ${response.status} ${response.statusText || ''} for ${url}`.trim()
+        `Request failed: ${response.status} ${response.statusText || ''} for ${url}`.trim()
       );
       err.status = response.status;
       throw err;
     }
   }
 
-  return { getJson, cache, headers };
+  const getJson = (url) => request(url, (r) => r.json());
+  const getText = (url) => request(url, (r) => r.text(), `text:${url}`);
+
+  return { getJson, getText, cache, headers };
 }
 
 module.exports = { createSecClient, createRateLimiter };

--- a/server/src/secClient.js
+++ b/server/src/secClient.js
@@ -1,0 +1,107 @@
+const config = require('./config');
+const { createCache } = require('./cache');
+
+// Spaces request *starts* by at least 1000/maxRequestsPerSecond ms so we never
+// exceed SEC's fair-access ceiling. The timing chain only gates request starts;
+// it does not wait for a request to finish, so independent requests can overlap.
+function createRateLimiter({ maxRequestsPerSecond, sleepImpl, now }) {
+  const minIntervalMs = 1000 / maxRequestsPerSecond;
+  let gate = Promise.resolve();
+  // So the very first request is not delayed.
+  let lastStart = Number.NEGATIVE_INFINITY;
+  return function run(task) {
+    const ready = gate.then(async () => {
+      const wait = Math.max(0, lastStart + minIntervalMs - now());
+      if (wait > 0) await sleepImpl(wait);
+      lastStart = now();
+    });
+    // Next caller waits only for this gate, not for `task` to resolve.
+    gate = ready.then(
+      () => undefined,
+      () => undefined
+    );
+    return ready.then(() => task());
+  };
+}
+
+const defaultSleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function createSecClient(options = {}) {
+  const {
+    fetchImpl = globalThis.fetch,
+    sleepImpl = defaultSleep,
+    now = () => Date.now(),
+    cache = createCache(config.cacheTtlMs),
+    userAgent = config.userAgent,
+    acceptEncoding = config.acceptEncoding,
+    maxRetries = config.maxRetries,
+    baseBackoffMs = config.baseBackoffMs,
+    maxRequestsPerSecond = config.maxRequestsPerSecond,
+  } = options;
+
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('No fetch implementation available. Use Node 18+ or inject fetchImpl.');
+  }
+
+  const limiter = createRateLimiter({ maxRequestsPerSecond, sleepImpl, now });
+
+  const headers = {
+    'User-Agent': userAgent,
+    'Accept-Encoding': acceptEncoding,
+    Accept: 'application/json',
+  };
+
+  function backoffDelay(attempt, response) {
+    const retryAfter = Number(response && response.headers && response.headers.get
+      ? response.headers.get('retry-after')
+      : NaN);
+    if (Number.isFinite(retryAfter) && retryAfter > 0) {
+      return retryAfter * 1000;
+    }
+    return baseBackoffMs * 2 ** attempt;
+  }
+
+  async function getJson(url) {
+    const cached = cache.get(url);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    let attempt = 0;
+    // Retry on 429 and 5xx (and network errors), with exponential backoff.
+    while (true) {
+      let response;
+      try {
+        response = await limiter(() => fetchImpl(url, { headers }));
+      } catch (err) {
+        if (attempt >= maxRetries) throw err;
+        await sleepImpl(baseBackoffMs * 2 ** attempt);
+        attempt += 1;
+        continue;
+      }
+
+      if (response.ok) {
+        const data = await response.json();
+        cache.set(url, data);
+        return data;
+      }
+
+      const retryable = response.status === 429 || response.status >= 500;
+      if (retryable && attempt < maxRetries) {
+        await sleepImpl(backoffDelay(attempt, response));
+        attempt += 1;
+        continue;
+      }
+
+      const err = new Error(
+        `SEC request failed: ${response.status} ${response.statusText || ''} for ${url}`.trim()
+      );
+      err.status = response.status;
+      throw err;
+    }
+  }
+
+  return { getJson, cache, headers };
+}
+
+module.exports = { createSecClient, createRateLimiter };

--- a/server/src/secService.js
+++ b/server/src/secService.js
@@ -270,8 +270,11 @@ function createSecService({ client, marketData, treasury, priceData } = {}) {
   }
 
   // GET /api/sec/segments (revenue by segment/geography/product from inline XBRL)
-  // Merges the most recent N 10-K filings for more years of history.
-  async function getSegments(rawTicker, { filings } = {}) {
+  // Merges the most recent N 10-K filings for more years of history. Each 10-K
+  // tags ~3 years, and consecutive filings overlap by 2, so N filings ≈ N+2
+  // distinct years. `years` is translated to the filings needed; `filings`
+  // overrides it directly.
+  async function getSegments(rawTicker, { filings, years } = {}) {
     const resolved = await resolveTicker(rawTicker);
     const submissions = await client.getJson(submissionsUrl(resolved.cik));
     const recent = submissions.filings && submissions.filings.recent;
@@ -279,7 +282,13 @@ function createSecService({ client, marketData, treasury, priceData } = {}) {
       throw notFound(`No filing history found for "${resolved.ticker}".`);
     }
 
-    const max = Math.min(Math.max(Number(filings) || 3, 1), 6);
+    const MAX_FILINGS = 10; // ~12 years; bounded to limit large-document fetches
+    let want = Number(filings);
+    if (!Number.isFinite(want) || want <= 0) {
+      const yrs = Number(years);
+      want = Number.isFinite(yrs) && yrs > 0 ? yrs - 2 : 3;
+    }
+    const max = Math.min(Math.max(Math.round(want), 1), MAX_FILINGS);
     const indices = [];
     for (let i = 0; i < recent.form.length && indices.length < max; i += 1) {
       if (recent.form[i] === '10-K' && recent.primaryDocument[i]) indices.push(i);

--- a/server/src/secService.js
+++ b/server/src/secService.js
@@ -12,6 +12,7 @@ const {
   parseRevenueFacts,
   toSingleAxisFacts,
   groupSegments,
+  deriveCombinedAxes,
   buildDiagnostics,
 } = require('./segments');
 const { getIndustryBeta } = require('./damodaran');
@@ -201,7 +202,12 @@ function createSecService({ client, marketData, treasury, priceData } = {}) {
     let marketCap = overview.marketCap;
     let marketCapSource = overview.marketCap != null ? overview.source : null;
     let priceError = null;
-    const shares = sharesOutstanding(facts);
+    // Prefer cover-page shares outstanding; fall back to weighted diluted/basic
+    // shares from the financials if the dei value is absent.
+    const shares =
+      sharesOutstanding(facts) ||
+      (period.dilutedShares != null ? period.dilutedShares : null) ||
+      (period.sharesBasic != null ? period.sharesBasic : null);
     if (marketCap == null) {
       try {
         const close = await price.getClose(resolved.ticker);
@@ -361,11 +367,15 @@ function createSecService({ client, marketData, treasury, priceData } = {}) {
         revenueFacts: p.revFacts.length,
         error: p.error,
       });
-      allRevFacts.push(...p.revFacts);
-      allSingle.push(...toSingleAxisFacts(p.revFacts.map((f) => ({ ...f, filed: p.doc.filed }))));
+      const tagged = p.revFacts.map((f) => ({ ...f, filed: p.doc.filed }));
+      allRevFacts.push(...tagged);
+      allSingle.push(...toSingleAxisFacts(tagged));
     }
 
     const grouped = groupSegments(allSingle);
+    // Surface breakdowns hidden inside multi-axis cells (e.g. revenue by region
+    // when it is tagged as region x product), summed across the other dimension.
+    grouped.axes = grouped.axes.concat(deriveCombinedAxes(allRevFacts));
     const latest = docFor(indices[0]);
 
     return {

--- a/server/src/secService.js
+++ b/server/src/secService.js
@@ -6,6 +6,7 @@ const { computeRatios } = require('./ratios');
 const { createMarketDataProvider } = require('./marketData');
 const { createTreasuryProvider } = require('./treasury');
 const { computeWacc } = require('./wacc');
+const { extractSegments } = require('./segments');
 const TAG_MAP = require('./tagMap');
 const { badRequest, notFound } = require('./errors');
 
@@ -165,6 +166,42 @@ function createSecService({ client, marketData, treasury } = {}) {
     };
   }
 
+  // GET /api/sec/segments (revenue by segment/geography/product from inline XBRL)
+  async function getSegments(rawTicker) {
+    const resolved = await resolveTicker(rawTicker);
+    const submissions = await client.getJson(submissionsUrl(resolved.cik));
+    const recent = submissions.filings && submissions.filings.recent;
+    if (!recent || !Array.isArray(recent.form)) {
+      throw notFound(`No filing history found for "${resolved.ticker}".`);
+    }
+    const idx = recent.form.findIndex((f) => f === '10-K');
+    if (idx === -1) throw notFound(`No 10-K filing found for "${resolved.ticker}".`);
+
+    const accession = recent.accessionNumber[idx];
+    const primaryDoc = recent.primaryDocument[idx];
+    const reportDate = recent.reportDate ? recent.reportDate[idx] : null;
+    if (!primaryDoc) throw notFound('Latest 10-K has no primary document to parse.');
+
+    const accnNoDash = String(accession).replace(/-/g, '');
+    const sourceDocument = `https://www.sec.gov/Archives/edgar/data/${resolved.cikNumber}/${accnNoDash}/${primaryDoc}`;
+    const xml = await client.getText(sourceDocument);
+    const grouped = extractSegments(xml);
+
+    return {
+      ticker: resolved.ticker,
+      cik: resolved.cik,
+      companyName: submissions.name || resolved.title,
+      accessionNumber: accession,
+      reportDate,
+      sourceDocument,
+      note:
+        grouped.axes.length === 0
+          ? 'No single-axis revenue breakdowns found. The filing may use older (non-inline) XBRL, custom axes, or only multi-dimensional cells.'
+          : undefined,
+      ...grouped,
+    };
+  }
+
   // GET /api/sec/all-facts (every annual us-gaap concept the company reported)
   async function getAllFacts(rawTicker, { years } = {}) {
     const resolved = await resolveTicker(rawTicker);
@@ -205,6 +242,7 @@ function createSecService({ client, marketData, treasury } = {}) {
     getProfile,
     getRatios,
     getWacc,
+    getSegments,
     getAllFacts,
     getFields,
     getConcept,

--- a/server/src/secService.js
+++ b/server/src/secService.js
@@ -1,5 +1,11 @@
+const config = require('./config');
 const { padCik, cikUrlParam, findTickerEntry } = require('./cikLookup');
 const { normalizeCompanyFacts, extractAllAnnualFacts } = require('./normalize');
+const { buildProfile } = require('./profile');
+const { computeRatios } = require('./ratios');
+const { createMarketDataProvider } = require('./marketData');
+const { createTreasuryProvider } = require('./treasury');
+const { computeWacc } = require('./wacc');
 const TAG_MAP = require('./tagMap');
 const { badRequest, notFound } = require('./errors');
 
@@ -28,7 +34,10 @@ function normalizeTicker(ticker) {
   return t;
 }
 
-function createSecService({ client }) {
+function createSecService({ client, marketData, treasury } = {}) {
+  const market = marketData || createMarketDataProvider({ client });
+  const treasuryProvider = treasury || createTreasuryProvider({ client });
+
   // Ticker -> { ticker, cik (padded), cikNumber, title }
   async function resolveTicker(rawTicker) {
     const ticker = normalizeTicker(rawTicker);
@@ -86,6 +95,76 @@ function createSecService({ client }) {
     };
   }
 
+  // GET /api/sec/profile (case-study profile: metadata + financial snapshot)
+  async function getProfile(rawTicker) {
+    const resolved = await resolveTicker(rawTicker);
+    const [submissions, facts] = await Promise.all([
+      client.getJson(submissionsUrl(resolved.cik)),
+      client.getJson(companyFactsUrl(resolved.cik)),
+    ]);
+    const modelData = normalizeCompanyFacts(facts, { years: 5 });
+    return buildProfile({ ticker: resolved.ticker, cik: resolved.cik, submissions, modelData });
+  }
+
+  // GET /api/sec/ratios (working-capital, liquidity, leverage, returns)
+  async function getRatios(rawTicker, { years } = {}) {
+    const resolved = await resolveTicker(rawTicker);
+    const facts = await client.getJson(companyFactsUrl(resolved.cik));
+    const modelData = normalizeCompanyFacts(facts, { years });
+    return {
+      ticker: resolved.ticker,
+      cik: resolved.cik,
+      companyName: modelData.companyName || resolved.title,
+      ratios: computeRatios(modelData.periods),
+    };
+  }
+
+  // GET /api/sec/wacc (cost of capital; market inputs from the configured provider)
+  async function getWacc(rawTicker, overrides = {}) {
+    const resolved = await resolveTicker(rawTicker);
+    const facts = await client.getJson(companyFactsUrl(resolved.cik));
+    const modelData = normalizeCompanyFacts(facts, { years: 2 });
+    const period = modelData.periods[0];
+    if (!period) throw notFound(`No annual 10-K data to compute WACC for "${resolved.ticker}".`);
+
+    // Market data (beta, market cap) and risk-free rate may fail or be
+    // unconfigured; WACC still returns with whatever is available + overrides.
+    let overview = { configured: market.configured, beta: null, marketCap: null, source: 'none' };
+    let marketError = null;
+    try {
+      overview = await market.getOverview(resolved.ticker);
+    } catch (err) {
+      marketError = err.message;
+    }
+    const rf = await treasuryProvider.getRiskFreeRate();
+
+    const result = computeWacc({
+      period,
+      beta: overview.beta,
+      marketCap: overview.marketCap,
+      riskFreeRate: rf.riskFreeRate,
+      equityRiskPremium: config.equityRiskPremiumDefault,
+      overrides,
+    });
+
+    return {
+      ticker: resolved.ticker,
+      cik: resolved.cik,
+      companyName: modelData.companyName || resolved.title,
+      ...result,
+      meta: {
+        marketDataConfigured: market.configured,
+        marketDataSource: overview.source,
+        marketDataError: marketError,
+        riskFreeRateSource: rf.source,
+        equityRiskPremiumDefault: config.equityRiskPremiumDefault,
+        note: market.configured
+          ? undefined
+          : 'No market-data API key set (ALPHAVANTAGE_API_KEY). Beta and market cap are null — pass them as query params (?beta=&marketCap=) or set a key.',
+      },
+    };
+  }
+
   // GET /api/sec/all-facts (every annual us-gaap concept the company reported)
   async function getAllFacts(rawTicker, { years } = {}) {
     const resolved = await resolveTicker(rawTicker);
@@ -123,6 +202,9 @@ function createSecService({ client }) {
     getCompany,
     getCompanyFacts,
     getModelData,
+    getProfile,
+    getRatios,
+    getWacc,
     getAllFacts,
     getFields,
     getConcept,

--- a/server/src/secService.js
+++ b/server/src/secService.js
@@ -6,6 +6,7 @@ const { computeRatios } = require('./ratios');
 const { createMarketDataProvider } = require('./marketData');
 const { createTreasuryProvider } = require('./treasury');
 const { computeWacc, effectiveTaxRate } = require('./wacc');
+const { buildScheduleIII } = require('./balanceSheet');
 const {
   parseRevenueFacts,
   toSingleAxisFacts,
@@ -125,6 +126,20 @@ function createSecService({ client, marketData, treasury, priceData } = {}) {
     ]);
     const modelData = normalizeCompanyFacts(facts, { years: 5 });
     return buildProfile({ ticker: resolved.ticker, cik: resolved.cik, submissions, modelData });
+  }
+
+  // GET /api/sec/balance-sheet (Companies Act 2013 Schedule III vertical format)
+  async function getBalanceSheet(rawTicker, { years } = {}) {
+    const resolved = await resolveTicker(rawTicker);
+    const facts = await client.getJson(companyFactsUrl(resolved.cik));
+    const modelData = normalizeCompanyFacts(facts, { years });
+    return {
+      ticker: resolved.ticker,
+      cik: resolved.cik,
+      companyName: modelData.companyName || resolved.title,
+      format: 'Companies Act 2013 — Schedule III (Division I), vertical',
+      statements: modelData.periods.map((p) => buildScheduleIII(p)),
+    };
   }
 
   // GET /api/sec/ratios (working-capital, liquidity, leverage, returns)
@@ -372,6 +387,7 @@ function createSecService({ client, marketData, treasury, priceData } = {}) {
     getModelData,
     getProfile,
     getBusinessSummary,
+    getBalanceSheet,
     getRatios,
     getWacc,
     getSegments,

--- a/server/src/secService.js
+++ b/server/src/secService.js
@@ -173,10 +173,14 @@ function createSecService({ client, marketData, treasury, priceData } = {}) {
   // GET /api/sec/wacc (cost of capital; market inputs from the configured provider)
   async function getWacc(rawTicker, overrides = {}) {
     const resolved = await resolveTicker(rawTicker);
-    const [facts, submissions] = await Promise.all([
-      client.getJson(companyFactsUrl(resolved.cik)),
-      client.getJson(submissionsUrl(resolved.cik)),
-    ]);
+    const facts = await client.getJson(companyFactsUrl(resolved.cik));
+    // Submissions (only needed for the industry SIC) must not break WACC.
+    let submissions = {};
+    try {
+      submissions = await client.getJson(submissionsUrl(resolved.cik));
+    } catch (_) {
+      submissions = {};
+    }
     const modelData = normalizeCompanyFacts(facts, { years: 2 });
     const period = modelData.periods[0];
     if (!period) throw notFound(`No annual 10-K data to compute WACC for "${resolved.ticker}".`);
@@ -196,16 +200,22 @@ function createSecService({ client, marketData, treasury, priceData } = {}) {
     // (Stooq latest close × SEC shares outstanding).
     let marketCap = overview.marketCap;
     let marketCapSource = overview.marketCap != null ? overview.source : null;
+    let priceError = null;
+    const shares = sharesOutstanding(facts);
     if (marketCap == null) {
       try {
         const close = await price.getClose(resolved.ticker);
-        const shares = sharesOutstanding(facts);
         if (close != null && shares != null) {
           marketCap = close * shares;
           marketCapSource = `${price.source}(close ${close}) × SEC(shares ${shares})`;
+        } else {
+          priceError =
+            close == null
+              ? `no price returned from ${price.source} for ${resolved.ticker}`
+              : 'no EntityCommonStockSharesOutstanding in SEC data';
         }
-      } catch (_) {
-        /* market cap stays null; user can pass ?marketCap= */
+      } catch (err) {
+        priceError = err.message;
       }
     }
 
@@ -222,6 +232,7 @@ function createSecService({ client, marketData, treasury, priceData } = {}) {
       period,
       beta: betaInfo.releveredBeta,
       marketCap,
+      bookEquity: period.stockholdersEquity,
       riskFreeRate: rf.riskFreeRate,
       equityRiskPremium: config.equityRiskPremiumDefault,
       overrides,
@@ -243,13 +254,16 @@ function createSecService({ client, marketData, treasury, priceData } = {}) {
         marketDataConfigured: market.configured,
         marketCapSource: marketCapSource || 'unavailable',
         marketDataError: marketError,
+        priceError,
+        sharesOutstanding: shares,
+        equityBasis: result.inputs.equityBasis,
         riskFreeRateSource: rf.source,
         equityRiskPremiumDefault: config.equityRiskPremiumDefault,
         betaNote:
           'Beta is an industry (Damodaran) asset beta re-levered with this company. Override with ?beta=.',
         marketCapNote:
           marketCap == null
-            ? 'Could not determine market cap (no API key and no free price) — pass ?marketCap= for the equity weight.'
+            ? `Market cap unavailable (${priceError || 'no source'}); WACC uses book equity for the weight — pass ?marketCap= for market weights.`
             : undefined,
       },
     };

--- a/server/src/secService.js
+++ b/server/src/secService.js
@@ -7,6 +7,7 @@ const { createMarketDataProvider } = require('./marketData');
 const { createTreasuryProvider } = require('./treasury');
 const { computeWacc, effectiveTaxRate } = require('./wacc');
 const { buildScheduleIII } = require('./balanceSheet');
+const { buildScheduleIIIPL } = require('./incomeStatement');
 const {
   parseRevenueFacts,
   toSingleAxisFacts,
@@ -139,6 +140,20 @@ function createSecService({ client, marketData, treasury, priceData } = {}) {
       companyName: modelData.companyName || resolved.title,
       format: 'Companies Act 2013 — Schedule III (Division I), vertical',
       statements: modelData.periods.map((p) => buildScheduleIII(p)),
+    };
+  }
+
+  // GET /api/sec/income-statement (Companies Act 2013 Schedule III, Part II)
+  async function getIncomeStatement(rawTicker, { years } = {}) {
+    const resolved = await resolveTicker(rawTicker);
+    const facts = await client.getJson(companyFactsUrl(resolved.cik));
+    const modelData = normalizeCompanyFacts(facts, { years });
+    return {
+      ticker: resolved.ticker,
+      cik: resolved.cik,
+      companyName: modelData.companyName || resolved.title,
+      format: 'Companies Act 2013 — Schedule III (Division I), Part II — Statement of Profit & Loss',
+      statements: modelData.periods.map((p) => buildScheduleIIIPL(p)),
     };
   }
 
@@ -397,6 +412,7 @@ function createSecService({ client, marketData, treasury, priceData } = {}) {
     getProfile,
     getBusinessSummary,
     getBalanceSheet,
+    getIncomeStatement,
     getRatios,
     getWacc,
     getSegments,

--- a/server/src/secService.js
+++ b/server/src/secService.js
@@ -6,7 +6,12 @@ const { computeRatios } = require('./ratios');
 const { createMarketDataProvider } = require('./marketData');
 const { createTreasuryProvider } = require('./treasury');
 const { computeWacc, effectiveTaxRate } = require('./wacc');
-const { extractSegments } = require('./segments');
+const {
+  parseRevenueFacts,
+  toSingleAxisFacts,
+  groupSegments,
+  buildDiagnostics,
+} = require('./segments');
 const { getIndustryBeta } = require('./damodaran');
 const { extractBusinessSection } = require('./filingText');
 const { createPriceProvider } = require('./priceData');
@@ -250,38 +255,81 @@ function createSecService({ client, marketData, treasury, priceData } = {}) {
   }
 
   // GET /api/sec/segments (revenue by segment/geography/product from inline XBRL)
-  async function getSegments(rawTicker) {
+  // Merges the most recent N 10-K filings for more years of history.
+  async function getSegments(rawTicker, { filings } = {}) {
     const resolved = await resolveTicker(rawTicker);
     const submissions = await client.getJson(submissionsUrl(resolved.cik));
     const recent = submissions.filings && submissions.filings.recent;
     if (!recent || !Array.isArray(recent.form)) {
       throw notFound(`No filing history found for "${resolved.ticker}".`);
     }
-    const idx = recent.form.findIndex((f) => f === '10-K');
-    if (idx === -1) throw notFound(`No 10-K filing found for "${resolved.ticker}".`);
 
-    const accession = recent.accessionNumber[idx];
-    const primaryDoc = recent.primaryDocument[idx];
-    const reportDate = recent.reportDate ? recent.reportDate[idx] : null;
-    if (!primaryDoc) throw notFound('Latest 10-K has no primary document to parse.');
+    const max = Math.min(Math.max(Number(filings) || 3, 1), 6);
+    const indices = [];
+    for (let i = 0; i < recent.form.length && indices.length < max; i += 1) {
+      if (recent.form[i] === '10-K' && recent.primaryDocument[i]) indices.push(i);
+    }
+    if (indices.length === 0) throw notFound(`No 10-K filing found for "${resolved.ticker}".`);
 
-    const accnNoDash = String(accession).replace(/-/g, '');
-    const sourceDocument = `https://www.sec.gov/Archives/edgar/data/${resolved.cikNumber}/${accnNoDash}/${primaryDoc}`;
-    const xml = await client.getText(sourceDocument);
-    const grouped = extractSegments(xml);
+    const docFor = (i) => {
+      const accession = recent.accessionNumber[i];
+      const accnNoDash = String(accession).replace(/-/g, '');
+      return {
+        accession,
+        filed: recent.filingDate ? recent.filingDate[i] : null,
+        reportDate: recent.reportDate ? recent.reportDate[i] : null,
+        sourceDocument: `https://www.sec.gov/Archives/edgar/data/${resolved.cikNumber}/${accnNoDash}/${recent.primaryDocument[i]}`,
+      };
+    };
+
+    const parsed = await Promise.all(
+      indices.map(async (i) => {
+        const doc = docFor(i);
+        try {
+          const xml = await client.getText(doc.sourceDocument);
+          const revFacts = parseRevenueFacts(xml);
+          return { doc, revFacts, ok: true };
+        } catch (err) {
+          return { doc, revFacts: [], ok: false, error: err.message };
+        }
+      })
+    );
+
+    const allRevFacts = [];
+    const allSingle = [];
+    const sources = [];
+    for (const p of parsed) {
+      sources.push({
+        accessionNumber: p.doc.accession,
+        filed: p.doc.filed,
+        reportDate: p.doc.reportDate,
+        sourceDocument: p.doc.sourceDocument,
+        parsed: p.ok,
+        revenueFacts: p.revFacts.length,
+        error: p.error,
+      });
+      allRevFacts.push(...p.revFacts);
+      allSingle.push(...toSingleAxisFacts(p.revFacts.map((f) => ({ ...f, filed: p.doc.filed }))));
+    }
+
+    const grouped = groupSegments(allSingle);
+    const latest = docFor(indices[0]);
 
     return {
       ticker: resolved.ticker,
       cik: resolved.cik,
       companyName: submissions.name || resolved.title,
-      accessionNumber: accession,
-      reportDate,
-      sourceDocument,
+      accessionNumber: latest.accession,
+      reportDate: latest.reportDate,
+      sourceDocument: latest.sourceDocument,
+      filingsParsed: sources.filter((s) => s.parsed).length,
+      sources,
+      ...grouped,
+      diagnostics: buildDiagnostics(allRevFacts),
       note:
         grouped.axes.length === 0
-          ? 'No single-axis revenue breakdowns found. The filing may use older (non-inline) XBRL, custom axes, or only multi-dimensional cells.'
+          ? 'No single-axis revenue breakdowns found. See diagnostics.axisCombinations — the company may only tag multi-axis (e.g. product x geography) cells, or use custom axes.'
           : undefined,
-      ...grouped,
     };
   }
 

--- a/server/src/secService.js
+++ b/server/src/secService.js
@@ -5,8 +5,10 @@ const { buildProfile } = require('./profile');
 const { computeRatios } = require('./ratios');
 const { createMarketDataProvider } = require('./marketData');
 const { createTreasuryProvider } = require('./treasury');
-const { computeWacc } = require('./wacc');
+const { computeWacc, effectiveTaxRate } = require('./wacc');
 const { extractSegments } = require('./segments');
+const { getIndustryBeta } = require('./damodaran');
+const { extractBusinessSection } = require('./filingText');
 const TAG_MAP = require('./tagMap');
 const { badRequest, notFound } = require('./errors');
 
@@ -124,13 +126,17 @@ function createSecService({ client, marketData, treasury } = {}) {
   // GET /api/sec/wacc (cost of capital; market inputs from the configured provider)
   async function getWacc(rawTicker, overrides = {}) {
     const resolved = await resolveTicker(rawTicker);
-    const facts = await client.getJson(companyFactsUrl(resolved.cik));
+    const [facts, submissions] = await Promise.all([
+      client.getJson(companyFactsUrl(resolved.cik)),
+      client.getJson(submissionsUrl(resolved.cik)),
+    ]);
     const modelData = normalizeCompanyFacts(facts, { years: 2 });
     const period = modelData.periods[0];
     if (!period) throw notFound(`No annual 10-K data to compute WACC for "${resolved.ticker}".`);
 
-    // Market data (beta, market cap) and risk-free rate may fail or be
-    // unconfigured; WACC still returns with whatever is available + overrides.
+    // Market cap (for the equity weight) is sourced from the market-data
+    // provider; it may be unconfigured/fail. Beta comes from a Damodaran
+    // INDUSTRY beta re-levered with the company's own D/E + tax rate.
     let overview = { configured: market.configured, beta: null, marketCap: null, source: 'none' };
     let marketError = null;
     try {
@@ -140,9 +146,15 @@ function createSecService({ client, marketData, treasury } = {}) {
     }
     const rf = await treasuryProvider.getRiskFreeRate();
 
+    const totalDebt = (period.shortTermDebt || 0) + (period.longTermDebt || 0) || null;
+    const taxRate = effectiveTaxRate(period);
+    const equityForLever = overview.marketCap != null ? overview.marketCap : period.stockholdersEquity;
+    const de = totalDebt != null && equityForLever ? totalDebt / equityForLever : null;
+    const betaInfo = getIndustryBeta({ sic: submissions.sic, de, taxRate });
+
     const result = computeWacc({
       period,
-      beta: overview.beta,
+      beta: betaInfo.releveredBeta,
       marketCap: overview.marketCap,
       riskFreeRate: rf.riskFreeRate,
       equityRiskPremium: config.equityRiskPremiumDefault,
@@ -154,16 +166,54 @@ function createSecService({ client, marketData, treasury } = {}) {
       cik: resolved.cik,
       companyName: modelData.companyName || resolved.title,
       ...result,
+      beta: {
+        ...betaInfo,
+        industryName: submissions.sicDescription || null,
+        sic: submissions.sic || null,
+        deRatioBasis: overview.marketCap != null ? 'market (market cap)' : 'book (equity)',
+        providerBeta: overview.beta,
+      },
       meta: {
         marketDataConfigured: market.configured,
         marketDataSource: overview.source,
         marketDataError: marketError,
         riskFreeRateSource: rf.source,
         equityRiskPremiumDefault: config.equityRiskPremiumDefault,
-        note: market.configured
+        betaNote:
+          'Beta is an industry (Damodaran) asset beta re-levered with this company. Override with ?beta=.',
+        marketCapNote: market.configured
           ? undefined
-          : 'No market-data API key set (ALPHAVANTAGE_API_KEY). Beta and market cap are null — pass them as query params (?beta=&marketCap=) or set a key.',
+          : 'No market-data API key (ALPHAVANTAGE_API_KEY): market cap is null, so equity weight needs ?marketCap= (or it falls back to book equity for D/E).',
       },
+    };
+  }
+
+  // GET /api/sec/business (Item 1 "Business" narrative from the latest 10-K)
+  async function getBusinessSummary(rawTicker) {
+    const resolved = await resolveTicker(rawTicker);
+    const submissions = await client.getJson(submissionsUrl(resolved.cik));
+    const recent = submissions.filings && submissions.filings.recent;
+    if (!recent || !Array.isArray(recent.form)) {
+      throw notFound(`No filing history found for "${resolved.ticker}".`);
+    }
+    const idx = recent.form.findIndex((f) => f === '10-K');
+    if (idx === -1) throw notFound(`No 10-K filing found for "${resolved.ticker}".`);
+
+    const accession = recent.accessionNumber[idx];
+    const primaryDoc = recent.primaryDocument[idx];
+    if (!primaryDoc) throw notFound('Latest 10-K has no primary document to parse.');
+    const accnNoDash = String(accession).replace(/-/g, '');
+    const sourceDocument = `https://www.sec.gov/Archives/edgar/data/${resolved.cikNumber}/${accnNoDash}/${primaryDoc}`;
+    const html = await client.getText(sourceDocument);
+    const business = extractBusinessSection(html);
+
+    return {
+      ticker: resolved.ticker,
+      cik: resolved.cik,
+      accessionNumber: accession,
+      sourceDocument,
+      business: business || null,
+      note: business ? undefined : 'Could not locate the Item 1 (Business) section in the latest 10-K.',
     };
   }
 
@@ -241,6 +291,7 @@ function createSecService({ client, marketData, treasury } = {}) {
     getCompanyFacts,
     getModelData,
     getProfile,
+    getBusinessSummary,
     getRatios,
     getWacc,
     getSegments,

--- a/server/src/secService.js
+++ b/server/src/secService.js
@@ -92,6 +92,7 @@ function createSecService({ client, marketData, treasury } = {}) {
       ticker: resolved.ticker,
       cik: resolved.cik,
       companyName: normalized.companyName || resolved.title,
+      warnings: normalized.warnings || [],
       periods: normalized.periods,
     };
   }

--- a/server/src/secService.js
+++ b/server/src/secService.js
@@ -9,6 +9,7 @@ const { computeWacc, effectiveTaxRate } = require('./wacc');
 const { extractSegments } = require('./segments');
 const { getIndustryBeta } = require('./damodaran');
 const { extractBusinessSection } = require('./filingText');
+const { createPriceProvider } = require('./priceData');
 const TAG_MAP = require('./tagMap');
 const { badRequest, notFound } = require('./errors');
 
@@ -37,9 +38,20 @@ function normalizeTicker(ticker) {
   return t;
 }
 
-function createSecService({ client, marketData, treasury } = {}) {
+// Latest cover-page shares outstanding from SEC dei data (for market cap).
+function sharesOutstanding(facts) {
+  const dei = facts && facts.facts && facts.facts.dei;
+  const node = dei && dei.EntityCommonStockSharesOutstanding;
+  const arr = node && node.units && node.units.shares;
+  if (!Array.isArray(arr) || !arr.length) return null;
+  const latest = [...arr].sort((a, b) => Date.parse(b.end || 0) - Date.parse(a.end || 0))[0];
+  return latest && Number.isFinite(latest.val) ? latest.val : null;
+}
+
+function createSecService({ client, marketData, treasury, priceData } = {}) {
   const market = marketData || createMarketDataProvider({ client });
   const treasuryProvider = treasury || createTreasuryProvider({ client });
+  const price = priceData || createPriceProvider({ client });
 
   // Ticker -> { ticker, cik (padded), cikNumber, title }
   async function resolveTicker(rawTicker) {
@@ -144,18 +156,37 @@ function createSecService({ client, marketData, treasury } = {}) {
     } catch (err) {
       marketError = err.message;
     }
+
+    // Market cap: from the keyed provider if available, else derive it free
+    // (Stooq latest close × SEC shares outstanding).
+    let marketCap = overview.marketCap;
+    let marketCapSource = overview.marketCap != null ? overview.source : null;
+    if (marketCap == null) {
+      try {
+        const close = await price.getClose(resolved.ticker);
+        const shares = sharesOutstanding(facts);
+        if (close != null && shares != null) {
+          marketCap = close * shares;
+          marketCapSource = `${price.source}(close ${close}) × SEC(shares ${shares})`;
+        }
+      } catch (_) {
+        /* market cap stays null; user can pass ?marketCap= */
+      }
+    }
+
     const rf = await treasuryProvider.getRiskFreeRate();
 
     const totalDebt = (period.shortTermDebt || 0) + (period.longTermDebt || 0) || null;
     const taxRate = effectiveTaxRate(period);
-    const equityForLever = overview.marketCap != null ? overview.marketCap : period.stockholdersEquity;
+    // Re-lever with MARKET D/E when market cap is known (book equity inflates beta).
+    const equityForLever = marketCap != null ? marketCap : period.stockholdersEquity;
     const de = totalDebt != null && equityForLever ? totalDebt / equityForLever : null;
     const betaInfo = getIndustryBeta({ sic: submissions.sic, de, taxRate });
 
     const result = computeWacc({
       period,
       beta: betaInfo.releveredBeta,
-      marketCap: overview.marketCap,
+      marketCap,
       riskFreeRate: rf.riskFreeRate,
       equityRiskPremium: config.equityRiskPremiumDefault,
       overrides,
@@ -170,20 +201,21 @@ function createSecService({ client, marketData, treasury } = {}) {
         ...betaInfo,
         industryName: submissions.sicDescription || null,
         sic: submissions.sic || null,
-        deRatioBasis: overview.marketCap != null ? 'market (market cap)' : 'book (equity)',
+        deRatioBasis: marketCap != null ? 'market (market cap)' : 'book (equity)',
         providerBeta: overview.beta,
       },
       meta: {
         marketDataConfigured: market.configured,
-        marketDataSource: overview.source,
+        marketCapSource: marketCapSource || 'unavailable',
         marketDataError: marketError,
         riskFreeRateSource: rf.source,
         equityRiskPremiumDefault: config.equityRiskPremiumDefault,
         betaNote:
           'Beta is an industry (Damodaran) asset beta re-levered with this company. Override with ?beta=.',
-        marketCapNote: market.configured
-          ? undefined
-          : 'No market-data API key (ALPHAVANTAGE_API_KEY): market cap is null, so equity weight needs ?marketCap= (or it falls back to book equity for D/E).',
+        marketCapNote:
+          marketCap == null
+            ? 'Could not determine market cap (no API key and no free price) — pass ?marketCap= for the equity weight.'
+            : undefined,
       },
     };
   }

--- a/server/src/secService.js
+++ b/server/src/secService.js
@@ -1,6 +1,18 @@
 const { padCik, cikUrlParam, findTickerEntry } = require('./cikLookup');
-const { normalizeCompanyFacts } = require('./normalize');
+const { normalizeCompanyFacts, extractAllAnnualFacts } = require('./normalize');
+const TAG_MAP = require('./tagMap');
 const { badRequest, notFound } = require('./errors');
+
+// Field metadata derived from the tag map (no network needed).
+function fieldDefinitions() {
+  return Object.entries(TAG_MAP).map(([key, def]) => ({
+    key,
+    label: def.label,
+    statement: def.statement,
+    unit: def.unit,
+    tags: def.tags,
+  }));
+}
 
 const TICKERS_URL = 'https://www.sec.gov/files/company_tickers.json';
 const submissionsUrl = (cik) => `https://data.sec.gov/submissions/${cikUrlParam(cik)}.json`;
@@ -74,6 +86,24 @@ function createSecService({ client }) {
     };
   }
 
+  // GET /api/sec/all-facts (every annual us-gaap concept the company reported)
+  async function getAllFacts(rawTicker, { years } = {}) {
+    const resolved = await resolveTicker(rawTicker);
+    const facts = await client.getJson(companyFactsUrl(resolved.cik));
+    const all = extractAllAnnualFacts(facts, { years });
+    return {
+      ticker: resolved.ticker,
+      cik: resolved.cik,
+      companyName: facts.entityName || resolved.title,
+      ...all,
+    };
+  }
+
+  // GET /api/sec/fields (metadata for the curated model — no network)
+  function getFields() {
+    return { fields: fieldDefinitions() };
+  }
+
   // GET /api/sec/concept (uses the company concept API the SEC exposes)
   async function getConcept(rawTicker, tag, taxonomy = 'us-gaap') {
     if (!tag) throw badRequest('Query parameter "tag" is required.');
@@ -88,7 +118,15 @@ function createSecService({ client }) {
     };
   }
 
-  return { resolveTicker, getCompany, getCompanyFacts, getModelData, getConcept };
+  return {
+    resolveTicker,
+    getCompany,
+    getCompanyFacts,
+    getModelData,
+    getAllFacts,
+    getFields,
+    getConcept,
+  };
 }
 
 module.exports = {

--- a/server/src/secService.js
+++ b/server/src/secService.js
@@ -1,0 +1,102 @@
+const { padCik, cikUrlParam, findTickerEntry } = require('./cikLookup');
+const { normalizeCompanyFacts } = require('./normalize');
+const { badRequest, notFound } = require('./errors');
+
+const TICKERS_URL = 'https://www.sec.gov/files/company_tickers.json';
+const submissionsUrl = (cik) => `https://data.sec.gov/submissions/${cikUrlParam(cik)}.json`;
+const companyFactsUrl = (cik) =>
+  `https://data.sec.gov/api/xbrl/companyfacts/${cikUrlParam(cik)}.json`;
+const companyConceptUrl = (cik, tag, taxonomy = 'us-gaap') =>
+  `https://data.sec.gov/api/xbrl/companyconcept/${cikUrlParam(cik)}/${taxonomy}/${tag}.json`;
+
+function normalizeTicker(ticker) {
+  const t = String(ticker || '').trim().toUpperCase();
+  if (!t) throw badRequest('Query parameter "ticker" is required.');
+  if (!/^[A-Z0-9.\-]{1,15}$/.test(t)) throw badRequest(`Invalid ticker: "${ticker}".`);
+  return t;
+}
+
+function createSecService({ client }) {
+  // Ticker -> { ticker, cik (padded), cikNumber, title }
+  async function resolveTicker(rawTicker) {
+    const ticker = normalizeTicker(rawTicker);
+    const mapping = await client.getJson(TICKERS_URL);
+    const entry = findTickerEntry(mapping, ticker);
+    if (!entry) {
+      throw notFound(`No SEC CIK found for ticker "${ticker}".`);
+    }
+    return {
+      ticker,
+      cik: padCik(entry.cik_str),
+      cikNumber: entry.cik_str,
+      title: entry.title,
+    };
+  }
+
+  // GET /api/sec/company
+  async function getCompany(rawTicker) {
+    const resolved = await resolveTicker(rawTicker);
+    const submissions = await client.getJson(submissionsUrl(resolved.cik));
+    return {
+      ticker: resolved.ticker,
+      cik: resolved.cik,
+      companyName: submissions.name || resolved.title,
+      tickers: submissions.tickers || [resolved.ticker],
+      exchanges: submissions.exchanges || [],
+      sic: submissions.sic || null,
+      sicDescription: submissions.sicDescription || null,
+      fiscalYearEnd: submissions.fiscalYearEnd || null,
+    };
+  }
+
+  // GET /api/sec/companyfacts (wrapped raw SEC payload)
+  async function getCompanyFacts(rawTicker) {
+    const resolved = await resolveTicker(rawTicker);
+    const facts = await client.getJson(companyFactsUrl(resolved.cik));
+    return {
+      ticker: resolved.ticker,
+      cik: resolved.cik,
+      companyName: facts.entityName || resolved.title,
+      facts,
+    };
+  }
+
+  // GET /api/sec/model-data
+  async function getModelData(rawTicker, { years } = {}) {
+    const resolved = await resolveTicker(rawTicker);
+    const facts = await client.getJson(companyFactsUrl(resolved.cik));
+    const normalized = normalizeCompanyFacts(facts, { years });
+    return {
+      ticker: resolved.ticker,
+      cik: resolved.cik,
+      companyName: normalized.companyName || resolved.title,
+      periods: normalized.periods,
+    };
+  }
+
+  // GET /api/sec/concept (uses the company concept API the SEC exposes)
+  async function getConcept(rawTicker, tag, taxonomy = 'us-gaap') {
+    if (!tag) throw badRequest('Query parameter "tag" is required.');
+    const resolved = await resolveTicker(rawTicker);
+    const concept = await client.getJson(companyConceptUrl(resolved.cik, tag, taxonomy));
+    return {
+      ticker: resolved.ticker,
+      cik: resolved.cik,
+      taxonomy,
+      tag,
+      concept,
+    };
+  }
+
+  return { resolveTicker, getCompany, getCompanyFacts, getModelData, getConcept };
+}
+
+module.exports = {
+  createSecService,
+  // exported for testing / reuse
+  TICKERS_URL,
+  submissionsUrl,
+  companyFactsUrl,
+  companyConceptUrl,
+  normalizeTicker,
+};

--- a/server/src/segments.js
+++ b/server/src/segments.js
@@ -1,0 +1,184 @@
+const { XMLParser } = require('fast-xml-parser');
+
+// Segment / geographic / product revenue breakdowns are NOT in the companyfacts
+// JSON API — they only exist as dimensional facts inside the filing's inline
+// XBRL (the primary 10-K .htm). This module parses that document, pairs each
+// dimensional revenue fact with its context's axis/member, and groups the
+// result by axis.
+
+const REVENUE_CONCEPTS = new Set([
+  'Revenues',
+  'RevenueFromContractWithCustomerExcludingAssessedTax',
+  'RevenueFromContractWithCustomerIncludingAssessedTax',
+  'SalesRevenueNet',
+  'RevenueFromContractWithCustomerExcludingAssessedTaxProductAndServiceBenchmark',
+]);
+
+// Axes that represent a revenue breakdown we care about.
+const isSegmentAxis = (dim) => /Segment|Geograph|ProductOrService/i.test(dim || '');
+
+const localName = (qname) => String(qname || '').split(':').pop();
+
+// "nflx:StreamingRevenuesMember" -> "Streaming Revenues"; "country:US" -> "US".
+function humanize(qname, stripSuffix) {
+  let s = localName(qname);
+  if (stripSuffix && s.endsWith(stripSuffix)) s = s.slice(0, -stripSuffix.length);
+  s = s.replace(/([a-z0-9])([A-Z])/g, '$1 $2').replace(/_/g, ' ').trim();
+  return s || qname;
+}
+
+// Recursively collect every value stored under `key` anywhere in the parsed tree.
+function collectByKey(node, key, acc = []) {
+  if (Array.isArray(node)) {
+    for (const n of node) collectByKey(n, key, acc);
+    return acc;
+  }
+  if (node && typeof node === 'object') {
+    for (const [k, v] of Object.entries(node)) {
+      if (k === key) {
+        if (Array.isArray(v)) acc.push(...v);
+        else acc.push(v);
+      }
+      collectByKey(v, key, acc);
+    }
+  }
+  return acc;
+}
+
+function isFullYear(start, end) {
+  const s = Date.parse(start);
+  const e = Date.parse(end);
+  if (Number.isNaN(s) || Number.isNaN(e)) return false;
+  const days = (e - s) / 86400000;
+  return days >= 350 && days <= 380;
+}
+
+function contextDimensions(ctx) {
+  const members = collectByKey(ctx, 'explicitMember');
+  return members
+    .map((m) => ({
+      dimension: m && m['@_dimension'],
+      member: m && (typeof m === 'object' ? m['#text'] : m),
+    }))
+    .filter((d) => d.dimension && d.member);
+}
+
+function contextPeriod(ctx) {
+  const period = ctx && ctx.period;
+  if (!period) return null;
+  if (period.endDate) return { start: period.startDate || null, end: period.endDate };
+  if (period.instant) return { start: null, end: period.instant };
+  return null;
+}
+
+function factValue(fact) {
+  const raw = typeof fact === 'object' ? fact['#text'] : fact;
+  if (raw == null) return null;
+  const cleaned = String(raw).replace(/,/g, '').trim();
+  let value = Number(cleaned);
+  if (!Number.isFinite(value)) return null;
+  const scale = Number(fact['@_scale']);
+  if (Number.isFinite(scale)) value *= 10 ** scale;
+  if (fact['@_sign'] === '-') value = -value;
+  return value;
+}
+
+function parseInlineXbrlSegments(xml, { concepts = REVENUE_CONCEPTS } = {}) {
+  if (!xml || typeof xml !== 'string') return [];
+  const parser = new XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: '@_',
+    removeNSPrefix: true,
+    textNodeName: '#text',
+    trimValues: true,
+    parseAttributeValue: false,
+  });
+
+  let tree;
+  try {
+    tree = parser.parse(xml);
+  } catch (_) {
+    return [];
+  }
+
+  // Build contextId -> { period, dimensions }
+  const contexts = {};
+  for (const ctx of collectByKey(tree, 'context')) {
+    const id = ctx && ctx['@_id'];
+    if (!id) continue;
+    contexts[id] = { period: contextPeriod(ctx), dimensions: contextDimensions(ctx) };
+  }
+
+  const facts = [];
+  for (const fact of collectByKey(tree, 'nonFraction')) {
+    if (!fact || typeof fact !== 'object') continue;
+    const concept = localName(fact['@_name']);
+    if (!concepts.has(concept)) continue;
+    const ctx = contexts[fact['@_contextRef']];
+    if (!ctx || !ctx.period || !ctx.period.end) continue;
+    if (!isFullYear(ctx.period.start, ctx.period.end)) continue;
+
+    const segDims = ctx.dimensions.filter((d) => isSegmentAxis(d.dimension));
+    // Only single-axis breakdowns (avoid double-counting product x geography cells).
+    if (segDims.length !== 1) continue;
+
+    const value = factValue(fact);
+    if (value == null) continue;
+
+    facts.push({
+      concept,
+      axis: segDims[0].dimension,
+      member: segDims[0].member,
+      value,
+      unit: localName(fact['@_unitRef']) || null,
+      fiscalYear: Number(ctx.period.end.slice(0, 4)),
+      periodEnd: ctx.period.end,
+    });
+  }
+  return facts;
+}
+
+// Group flat facts into { axes: [ { axis, label, members: [ { member, label, values } ] } ] }.
+function groupSegments(facts) {
+  const yearSet = new Set();
+  const axisMap = new Map();
+
+  for (const f of facts) {
+    yearSet.add(f.fiscalYear);
+    if (!axisMap.has(f.axis)) {
+      axisMap.set(f.axis, { axis: f.axis, label: humanize(f.axis, 'Axis'), members: new Map() });
+    }
+    const members = axisMap.get(f.axis).members;
+    if (!members.has(f.member)) {
+      members.set(f.member, { member: f.member, label: humanize(f.member, 'Member'), values: {} });
+    }
+    // Keep the largest absolute value if the same member/year appears twice.
+    const slot = members.get(f.member).values;
+    if (slot[f.fiscalYear] == null || Math.abs(f.value) > Math.abs(slot[f.fiscalYear])) {
+      slot[f.fiscalYear] = f.value;
+    }
+  }
+
+  const axes = [...axisMap.values()].map((a) => ({
+    axis: a.axis,
+    label: a.label,
+    members: [...a.members.values()].sort((x, y) => {
+      const latest = Math.max(...Object.keys({ ...x.values, ...y.values }).map(Number));
+      return (y.values[latest] || 0) - (x.values[latest] || 0);
+    }),
+  }));
+
+  return { fiscalYears: [...yearSet].sort((a, b) => b - a), factCount: facts.length, axes };
+}
+
+function extractSegments(xml) {
+  return groupSegments(parseInlineXbrlSegments(xml));
+}
+
+module.exports = {
+  parseInlineXbrlSegments,
+  groupSegments,
+  extractSegments,
+  humanize,
+  REVENUE_CONCEPTS,
+};

--- a/server/src/segments.js
+++ b/server/src/segments.js
@@ -204,6 +204,50 @@ function groupSegments(facts) {
   return { fiscalYears: [...yearSet].sort((a, b) => b - a), factCount: facts.length, axes };
 }
 
+// Derive a single-axis breakdown by summing MULTI-axis cells over the other
+// dimension(s) — e.g. revenue by geography summed across products. Only uses
+// facts with >=2 segment axes (single-axis ones are already grouped directly),
+// de-duping the same dimensional cell across filings (latest filed wins) before
+// summing. Clearly flagged derived; verify against the filing.
+function aggregateAxis(revFacts, axis) {
+  const dedup = new Map();
+  for (const f of revFacts) {
+    if (f.segmentDims.length < 2) continue;
+    if (!f.segmentDims.some((d) => d.axis === axis)) continue;
+    const sig = f.segmentDims.map((d) => `${d.axis}=${d.member}`).sort().join('|') + '@' + f.fiscalYear;
+    const prev = dedup.get(sig);
+    const newer = !prev || (f.filed && (!prev.filed || Date.parse(f.filed) > Date.parse(prev.filed)));
+    if (newer) dedup.set(sig, f);
+  }
+  const members = new Map();
+  const years = new Set();
+  for (const f of dedup.values()) {
+    years.add(f.fiscalYear);
+    const member = f.segmentDims.find((d) => d.axis === axis).member;
+    if (!members.has(member)) members.set(member, { member, label: humanize(member, 'Member'), values: {} });
+    const vals = members.get(member).values;
+    vals[f.fiscalYear] = (vals[f.fiscalYear] || 0) + f.value;
+  }
+  return {
+    axis,
+    label: `${humanize(axis, 'Axis')} (summed across other dimensions)`,
+    derived: true,
+    members: [...members.values()].sort((x, y) => {
+      const yr = Math.max(...Object.keys({ ...x.values, ...y.values }).map(Number));
+      return (y.values[yr] || 0) - (x.values[yr] || 0);
+    }),
+  };
+}
+
+// Derived axes for every axis that appears in any multi-axis (>=2) combination.
+function deriveCombinedAxes(revFacts) {
+  const axes = new Set();
+  for (const f of revFacts) {
+    if (f.segmentDims.length >= 2) for (const d of f.segmentDims) axes.add(d.axis);
+  }
+  return [...axes].map((a) => aggregateAxis(revFacts, a)).filter((a) => a.members.length > 0);
+}
+
 // Reveal every axis/member and axis-combination seen (incl. multi-axis cells).
 function buildDiagnostics(revFacts) {
   const axisMembers = new Map();
@@ -240,6 +284,8 @@ module.exports = {
   parseRevenueFacts,
   toSingleAxisFacts,
   groupSegments,
+  aggregateAxis,
+  deriveCombinedAxes,
   buildDiagnostics,
   extractSegments,
   humanize,

--- a/server/src/segments.js
+++ b/server/src/segments.js
@@ -3,8 +3,9 @@ const { XMLParser } = require('fast-xml-parser');
 // Segment / geographic / product revenue breakdowns are NOT in the companyfacts
 // JSON API — they only exist as dimensional facts inside the filing's inline
 // XBRL (the primary 10-K .htm). This module parses that document, pairs each
-// dimensional revenue fact with its context's axis/member, and groups the
-// result by axis.
+// dimensional revenue fact with its context's axis/member(s), and groups the
+// single-axis breakdowns by axis. A diagnostics view exposes every axis/member
+// combination seen (including multi-axis cells) to make tuning transparent.
 
 const REVENUE_CONCEPTS = new Set([
   'Revenues',
@@ -15,7 +16,8 @@ const REVENUE_CONCEPTS = new Set([
 ]);
 
 // Axes that represent a revenue breakdown we care about.
-const isSegmentAxis = (dim) => /Segment|Geograph|ProductOrService/i.test(dim || '');
+const isSegmentAxis = (dim) =>
+  /Segment|Geograph|ProductOrService|Region|Brand|MajorCustomer|Country|Subscription/i.test(dim || '');
 
 const localName = (qname) => String(qname || '').split(':').pop();
 
@@ -27,7 +29,6 @@ function humanize(qname, stripSuffix) {
   return s || qname;
 }
 
-// Recursively collect every value stored under `key` anywhere in the parsed tree.
 function collectByKey(node, key, acc = []) {
   if (Array.isArray(node)) {
     for (const n of node) collectByKey(n, key, acc);
@@ -54,8 +55,7 @@ function isFullYear(start, end) {
 }
 
 function contextDimensions(ctx) {
-  const members = collectByKey(ctx, 'explicitMember');
-  return members
+  return collectByKey(ctx, 'explicitMember')
     .map((m) => ({
       dimension: m && m['@_dimension'],
       member: m && (typeof m === 'object' ? m['#text'] : m),
@@ -74,8 +74,7 @@ function contextPeriod(ctx) {
 function factValue(fact) {
   const raw = typeof fact === 'object' ? fact['#text'] : fact;
   if (raw == null) return null;
-  const cleaned = String(raw).replace(/,/g, '').trim();
-  let value = Number(cleaned);
+  let value = Number(String(raw).replace(/,/g, '').trim());
   if (!Number.isFinite(value)) return null;
   const scale = Number(fact['@_scale']);
   if (Number.isFinite(scale)) value *= 10 ** scale;
@@ -83,7 +82,9 @@ function factValue(fact) {
   return value;
 }
 
-function parseInlineXbrlSegments(xml, { concepts = REVENUE_CONCEPTS } = {}) {
+// All full-year revenue facts that carry >=1 segment-axis dimension, with their
+// complete segment-dimension list.
+function parseRevenueFacts(xml, { concepts = REVENUE_CONCEPTS } = {}) {
   if (!xml || typeof xml !== 'string') return [];
   const parser = new XMLParser({
     ignoreAttributes: false,
@@ -93,7 +94,6 @@ function parseInlineXbrlSegments(xml, { concepts = REVENUE_CONCEPTS } = {}) {
     trimValues: true,
     parseAttributeValue: false,
   });
-
   let tree;
   try {
     tree = parser.parse(xml);
@@ -101,7 +101,6 @@ function parseInlineXbrlSegments(xml, { concepts = REVENUE_CONCEPTS } = {}) {
     return [];
   }
 
-  // Build contextId -> { period, dimensions }
   const contexts = {};
   for (const ctx of collectByKey(tree, 'context')) {
     const id = ctx && ctx['@_id'];
@@ -118,17 +117,17 @@ function parseInlineXbrlSegments(xml, { concepts = REVENUE_CONCEPTS } = {}) {
     if (!ctx || !ctx.period || !ctx.period.end) continue;
     if (!isFullYear(ctx.period.start, ctx.period.end)) continue;
 
-    const segDims = ctx.dimensions.filter((d) => isSegmentAxis(d.dimension));
-    // Only single-axis breakdowns (avoid double-counting product x geography cells).
-    if (segDims.length !== 1) continue;
+    const segmentDims = ctx.dimensions
+      .filter((d) => isSegmentAxis(d.dimension))
+      .map((d) => ({ axis: d.dimension, member: d.member }));
+    if (segmentDims.length === 0) continue;
 
     const value = factValue(fact);
     if (value == null) continue;
 
     facts.push({
       concept,
-      axis: segDims[0].dimension,
-      member: segDims[0].member,
+      segmentDims,
       value,
       unit: localName(fact['@_unitRef']) || null,
       fiscalYear: Number(ctx.period.end.slice(0, 4)),
@@ -138,7 +137,30 @@ function parseInlineXbrlSegments(xml, { concepts = REVENUE_CONCEPTS } = {}) {
   return facts;
 }
 
-// Group flat facts into { axes: [ { axis, label, members: [ { member, label, values } ] } ] }.
+// Single-axis breakdown facts (used for the grouped tables).
+function toSingleAxisFacts(revFacts) {
+  return revFacts
+    .filter((f) => f.segmentDims.length === 1)
+    .map((f) => ({
+      concept: f.concept,
+      axis: f.segmentDims[0].axis,
+      member: f.segmentDims[0].member,
+      value: f.value,
+      unit: f.unit,
+      fiscalYear: f.fiscalYear,
+      periodEnd: f.periodEnd,
+      filed: f.filed || null,
+    }));
+}
+
+function parseInlineXbrlSegments(xml, opts) {
+  return toSingleAxisFacts(parseRevenueFacts(xml, opts));
+}
+const parseDimensionalFacts = (xml, opts) => parseRevenueFacts(xml, opts);
+
+// Group single-axis facts into { axes: [ { axis, label, members:[{member,label,values}] } ] }.
+// When facts carry a `filed` date (multi-filing merge), the most recently filed
+// value wins for each member/year; otherwise the larger absolute value wins.
 function groupSegments(facts) {
   const yearSet = new Set();
   const axisMap = new Map();
@@ -150,25 +172,62 @@ function groupSegments(facts) {
     }
     const members = axisMap.get(f.axis).members;
     if (!members.has(f.member)) {
-      members.set(f.member, { member: f.member, label: humanize(f.member, 'Member'), values: {} });
+      members.set(f.member, { member: f.member, label: humanize(f.member, 'Member'), values: {}, _filed: {} });
     }
-    // Keep the largest absolute value if the same member/year appears twice.
-    const slot = members.get(f.member).values;
-    if (slot[f.fiscalYear] == null || Math.abs(f.value) > Math.abs(slot[f.fiscalYear])) {
-      slot[f.fiscalYear] = f.value;
+    const slot = members.get(f.member);
+    const have = slot.values[f.fiscalYear];
+    const prevFiled = slot._filed[f.fiscalYear];
+    const better =
+      have == null ||
+      (f.filed && (!prevFiled || Date.parse(f.filed) > Date.parse(prevFiled))) ||
+      (!f.filed && Math.abs(f.value) > Math.abs(have));
+    if (better) {
+      slot.values[f.fiscalYear] = f.value;
+      slot._filed[f.fiscalYear] = f.filed || null;
     }
   }
 
   const axes = [...axisMap.values()].map((a) => ({
     axis: a.axis,
     label: a.label,
-    members: [...a.members.values()].sort((x, y) => {
-      const latest = Math.max(...Object.keys({ ...x.values, ...y.values }).map(Number));
-      return (y.values[latest] || 0) - (x.values[latest] || 0);
-    }),
+    members: [...a.members.values()]
+      .map((m) => {
+        delete m._filed;
+        return m;
+      })
+      .sort((x, y) => {
+        const yr = Math.max(...Object.keys({ ...x.values, ...y.values }).map(Number));
+        return (y.values[yr] || 0) - (x.values[yr] || 0);
+      }),
   }));
 
   return { fiscalYears: [...yearSet].sort((a, b) => b - a), factCount: facts.length, axes };
+}
+
+// Reveal every axis/member and axis-combination seen (incl. multi-axis cells).
+function buildDiagnostics(revFacts) {
+  const axisMembers = new Map();
+  const combos = new Map();
+  for (const f of revFacts) {
+    const axes = f.segmentDims.map((d) => d.axis).sort();
+    const key = axes.map(localName).join(' + ') || '(none)';
+    combos.set(key, (combos.get(key) || 0) + 1);
+    for (const d of f.segmentDims) {
+      if (!axisMembers.has(d.axis)) axisMembers.set(d.axis, new Set());
+      axisMembers.get(d.axis).add(d.member);
+    }
+  }
+  return {
+    totalRevenueFacts: revFacts.length,
+    axesSeen: [...axisMembers.entries()].map(([axis, set]) => ({
+      axis,
+      label: humanize(axis, 'Axis'),
+      members: [...set],
+    })),
+    axisCombinations: [...combos.entries()]
+      .map(([axes, count]) => ({ axes, count }))
+      .sort((a, b) => b.count - a.count),
+  };
 }
 
 function extractSegments(xml) {
@@ -177,7 +236,11 @@ function extractSegments(xml) {
 
 module.exports = {
   parseInlineXbrlSegments,
+  parseDimensionalFacts,
+  parseRevenueFacts,
+  toSingleAxisFacts,
   groupSegments,
+  buildDiagnostics,
   extractSegments,
   humanize,
   REVENUE_CONCEPTS,

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -1,0 +1,23 @@
+const config = require('./config');
+const { createSecClient } = require('./secClient');
+const { createSecService } = require('./secService');
+const { createApp } = require('./app');
+
+function start() {
+  const client = createSecClient();
+  const service = createSecService({ client });
+  const app = createApp({ service });
+
+  app.listen(config.port, () => {
+    // eslint-disable-next-line no-console
+    console.log(`SEC EDGAR backend listening on http://localhost:${config.port}`);
+    // eslint-disable-next-line no-console
+    console.log(`Using SEC User-Agent: "${config.userAgent}"`);
+  });
+}
+
+if (require.main === module) {
+  start();
+}
+
+module.exports = { start };

--- a/server/src/tagMap.js
+++ b/server/src/tagMap.js
@@ -1,0 +1,72 @@
+// Maps each financial-modelling field to the US-GAAP XBRL tags that may carry
+// it, in priority order. The first tag that has data for a given fiscal year
+// wins. `unit` is the preferred XBRL unit; if absent the normalizer falls back
+// to whatever unit the company actually reported (recorded for auditability).
+//
+// Insertion order here also defines the field order in the normalized output.
+module.exports = {
+  revenue: {
+    unit: 'USD',
+    tags: ['Revenues', 'RevenueFromContractWithCustomerExcludingAssessedTax'],
+  },
+  costOfRevenue: {
+    unit: 'USD',
+    tags: ['CostOfRevenue', 'CostOfGoodsAndServicesSold'],
+  },
+  grossProfit: {
+    unit: 'USD',
+    tags: ['GrossProfit'],
+  },
+  operatingIncome: {
+    unit: 'USD',
+    tags: ['OperatingIncomeLoss'],
+  },
+  netIncome: {
+    unit: 'USD',
+    tags: ['NetIncomeLoss'],
+  },
+  totalAssets: {
+    unit: 'USD',
+    tags: ['Assets'],
+  },
+  currentAssets: {
+    unit: 'USD',
+    tags: ['AssetsCurrent'],
+  },
+  cashAndEquivalents: {
+    unit: 'USD',
+    tags: [
+      'CashAndCashEquivalentsAtCarryingValue',
+      'CashCashEquivalentsRestrictedCashAndRestrictedCashEquivalents',
+    ],
+  },
+  totalLiabilities: {
+    unit: 'USD',
+    // Direct tag only. A computed fallback (LiabilitiesCurrent +
+    // LiabilitiesNoncurrent) is applied in the normalizer when this is absent.
+    tags: ['Liabilities'],
+  },
+  stockholdersEquity: {
+    unit: 'USD',
+    tags: [
+      'StockholdersEquity',
+      'StockholdersEquityIncludingPortionAttributableToNoncontrollingInterest',
+    ],
+  },
+  operatingCashFlow: {
+    unit: 'USD',
+    tags: ['NetCashProvidedByUsedInOperatingActivities'],
+  },
+  capitalExpenditure: {
+    unit: 'USD',
+    tags: ['PaymentsToAcquirePropertyPlantAndEquipment'],
+  },
+  dilutedEPS: {
+    unit: 'USD/shares',
+    tags: ['EarningsPerShareDiluted'],
+  },
+  dilutedShares: {
+    unit: 'shares',
+    tags: ['WeightedAverageNumberOfDilutedSharesOutstanding'],
+  },
+};

--- a/server/src/tagMap.js
+++ b/server/src/tagMap.js
@@ -70,7 +70,13 @@ module.exports = {
     statement: 'income',
     label: 'Interest Expense',
     unit: 'USD',
-    tags: ['InterestExpense', 'InterestExpenseDebt', 'InterestAndDebtExpense'],
+    tags: [
+      'InterestExpense',
+      'InterestExpenseDebt',
+      'InterestAndDebtExpense',
+      'InterestExpenseNonoperating',
+      'InterestIncomeExpenseNonoperatingNet',
+    ],
   },
   interestIncome: {
     statement: 'income',
@@ -107,28 +113,34 @@ module.exports = {
   },
 
   // ---- Per share ---------------------------------------------------------
+  // preferLatestFiling: use the most recently filed value for each year so the
+  // series is split-adjusted (a later 10-K restates prior years for splits).
   epsBasic: {
     statement: 'pershare',
     label: 'EPS (Basic)',
     unit: 'USD/shares',
+    preferLatestFiling: true,
     tags: ['EarningsPerShareBasic'],
   },
   dilutedEPS: {
     statement: 'pershare',
     label: 'EPS (Diluted)',
     unit: 'USD/shares',
+    preferLatestFiling: true,
     tags: ['EarningsPerShareDiluted'],
   },
   sharesBasic: {
     statement: 'pershare',
     label: 'Shares (Basic)',
     unit: 'shares',
+    preferLatestFiling: true,
     tags: ['WeightedAverageNumberOfSharesOutstandingBasic'],
   },
   dilutedShares: {
     statement: 'pershare',
     label: 'Shares (Diluted)',
     unit: 'shares',
+    preferLatestFiling: true,
     tags: ['WeightedAverageNumberOfDilutedSharesOutstanding'],
   },
   dividendsPerShare: {
@@ -186,12 +198,30 @@ module.exports = {
     unit: 'USD',
     tags: ['IntangibleAssetsNetExcludingGoodwill', 'FiniteLivedIntangibleAssetsNet'],
   },
+  otherNoncurrentAssets: {
+    statement: 'balance',
+    label: 'Other Non-Current Assets',
+    unit: 'USD',
+    tags: ['OtherAssetsNoncurrent'],
+  },
   totalAssets: { statement: 'balance', label: 'Total Assets', unit: 'USD', tags: ['Assets'] },
   accountsPayable: {
     statement: 'balance',
     label: 'Accounts Payable',
     unit: 'USD',
-    tags: ['AccountsPayableCurrent', 'AccountsPayableAndAccruedLiabilitiesCurrent'],
+    tags: ['AccountsPayableCurrent'],
+  },
+  accruedLiabilities: {
+    statement: 'balance',
+    label: 'Accrued Liabilities',
+    unit: 'USD',
+    tags: ['AccruedLiabilitiesCurrent', 'AccountsPayableAndAccruedLiabilitiesCurrent'],
+  },
+  otherCurrentLiabilities: {
+    statement: 'balance',
+    label: 'Other Current Liabilities',
+    unit: 'USD',
+    tags: ['OtherLiabilitiesCurrent'],
   },
   shortTermDebt: {
     statement: 'balance',
@@ -216,6 +246,18 @@ module.exports = {
     label: 'Long-Term Debt',
     unit: 'USD',
     tags: ['LongTermDebtNoncurrent', 'LongTermDebt'],
+  },
+  otherNoncurrentLiabilities: {
+    statement: 'balance',
+    label: 'Other Non-Current Liabilities',
+    unit: 'USD',
+    tags: ['OtherLiabilitiesNoncurrent'],
+  },
+  deferredTaxLiabilities: {
+    statement: 'balance',
+    label: 'Deferred Tax Liabilities',
+    unit: 'USD',
+    tags: ['DeferredIncomeTaxLiabilitiesNet', 'DeferredTaxLiabilitiesNoncurrent'],
   },
   totalLiabilities: {
     statement: 'balance',
@@ -247,6 +289,9 @@ module.exports = {
     statement: 'balance',
     label: 'Treasury Stock',
     unit: 'USD',
+    // Reported as a positive contra amount; normalize to negative so equity
+    // components sum to total equity.
+    negate: true,
     tags: ['TreasuryStockValue', 'TreasuryStockCommonValue'],
   },
   accumulatedOCI: {
@@ -276,11 +321,35 @@ module.exports = {
       'DepreciationAndAmortization',
     ],
   },
+  amortizationOfIntangibles: {
+    statement: 'cashflow',
+    label: 'Amortization of Intangibles/Content',
+    unit: 'USD',
+    tags: ['AmortizationOfIntangibleAssets', 'AmortizationOfDeferredCharges'],
+  },
   stockBasedCompensation: {
     statement: 'cashflow',
     label: 'Stock-Based Compensation',
     unit: 'USD',
     tags: ['ShareBasedCompensation'],
+  },
+  deferredIncomeTaxes: {
+    statement: 'cashflow',
+    label: 'Deferred Income Taxes',
+    unit: 'USD',
+    tags: ['DeferredIncomeTaxExpenseBenefit', 'DeferredIncomeTaxesAndTaxCredits'],
+  },
+  otherNoncashItems: {
+    statement: 'cashflow',
+    label: 'Other Non-Cash Items',
+    unit: 'USD',
+    tags: ['OtherNoncashIncomeExpense'],
+  },
+  changeInWorkingCapital: {
+    statement: 'cashflow',
+    label: 'Change in Working Capital',
+    unit: 'USD',
+    tags: ['IncreaseDecreaseInOperatingCapital'],
   },
   operatingCashFlow: {
     statement: 'cashflow',
@@ -330,6 +399,12 @@ module.exports = {
     unit: 'USD',
     tags: ['PaymentsForRepurchaseOfCommonStock'],
   },
+  stockIssued: {
+    statement: 'cashflow',
+    label: 'Stock Issued',
+    unit: 'USD',
+    tags: ['ProceedsFromIssuanceOfCommonStock', 'ProceedsFromStockOptionsExercised'],
+  },
   dividendsPaid: {
     statement: 'cashflow',
     label: 'Dividends Paid',
@@ -343,6 +418,24 @@ module.exports = {
     tags: [
       'NetCashProvidedByUsedInFinancingActivities',
       'NetCashProvidedByUsedInFinancingActivitiesContinuingOperations',
+    ],
+  },
+  effectOfExchangeRate: {
+    statement: 'cashflow',
+    label: 'Effect of Exchange Rate on Cash',
+    unit: 'USD',
+    tags: [
+      'EffectOfExchangeRateOnCashCashEquivalentsRestrictedCashAndRestrictedCashEquivalents',
+      'EffectOfExchangeRateOnCashAndCashEquivalents',
+    ],
+  },
+  netChangeInCash: {
+    statement: 'cashflow',
+    label: 'Net Change in Cash',
+    unit: 'USD',
+    tags: [
+      'CashCashEquivalentsRestrictedCashAndRestrictedCashEquivalentsPeriodIncreaseDecreaseIncludingExchangeRateEffect',
+      'CashAndCashEquivalentsPeriodIncreaseDecrease',
     ],
   },
 };

--- a/server/src/tagMap.js
+++ b/server/src/tagMap.js
@@ -1,72 +1,348 @@
 // Maps each financial-modelling field to the US-GAAP XBRL tags that may carry
-// it, in priority order. The first tag that has data for a given fiscal year
-// wins. `unit` is the preferred XBRL unit; if absent the normalizer falls back
-// to whatever unit the company actually reported (recorded for auditability).
+// it, in priority order. The first tag with data for a given fiscal year wins.
+// `unit` is the preferred XBRL unit (the normalizer falls back to whatever the
+// company actually reported, and records it for auditability). `statement` and
+// `label` drive grouping/labels in the UI and the /api/sec/fields endpoint.
 //
 // Insertion order here also defines the field order in the normalized output.
+//
+// This is a curated set covering the standard three statements. It is NOT
+// exhaustive — companies tag hundreds of concepts (and custom extensions). Use
+// the /api/sec/all-facts endpoint to retrieve every annual concept a company
+// reported.
 module.exports = {
+  // ---- Income statement --------------------------------------------------
   revenue: {
+    statement: 'income',
+    label: 'Revenue',
     unit: 'USD',
-    tags: ['Revenues', 'RevenueFromContractWithCustomerExcludingAssessedTax'],
+    tags: [
+      'Revenues',
+      'RevenueFromContractWithCustomerExcludingAssessedTax',
+      'RevenueFromContractWithCustomerIncludingAssessedTax',
+      'SalesRevenueNet',
+    ],
   },
   costOfRevenue: {
+    statement: 'income',
+    label: 'Cost of Revenue',
     unit: 'USD',
-    tags: ['CostOfRevenue', 'CostOfGoodsAndServicesSold'],
+    tags: ['CostOfRevenue', 'CostOfGoodsAndServicesSold', 'CostOfGoodsSold'],
   },
-  grossProfit: {
+  grossProfit: { statement: 'income', label: 'Gross Profit', unit: 'USD', tags: ['GrossProfit'] },
+  researchAndDevelopment: {
+    statement: 'income',
+    label: 'R&D Expense',
     unit: 'USD',
-    tags: ['GrossProfit'],
+    tags: ['ResearchAndDevelopmentExpense'],
+  },
+  sellingAndMarketing: {
+    statement: 'income',
+    label: 'Selling & Marketing',
+    unit: 'USD',
+    tags: ['SellingAndMarketingExpense', 'MarketingExpense'],
+  },
+  generalAndAdministrative: {
+    statement: 'income',
+    label: 'General & Administrative',
+    unit: 'USD',
+    tags: ['GeneralAndAdministrativeExpense'],
+  },
+  sellingGeneralAndAdministrative: {
+    statement: 'income',
+    label: 'SG&A (combined)',
+    unit: 'USD',
+    tags: ['SellingGeneralAndAdministrativeExpense'],
+  },
+  totalOperatingExpenses: {
+    statement: 'income',
+    label: 'Total Operating Expenses',
+    unit: 'USD',
+    tags: ['OperatingExpenses', 'CostsAndExpenses'],
   },
   operatingIncome: {
+    statement: 'income',
+    label: 'Operating Income',
     unit: 'USD',
     tags: ['OperatingIncomeLoss'],
   },
+  interestExpense: {
+    statement: 'income',
+    label: 'Interest Expense',
+    unit: 'USD',
+    tags: ['InterestExpense', 'InterestExpenseDebt', 'InterestAndDebtExpense'],
+  },
+  interestIncome: {
+    statement: 'income',
+    label: 'Interest / Investment Income',
+    unit: 'USD',
+    tags: ['InvestmentIncomeInterest', 'InterestAndOtherIncome'],
+  },
+  otherIncomeExpense: {
+    statement: 'income',
+    label: 'Other Non-Operating Income',
+    unit: 'USD',
+    tags: ['NonoperatingIncomeExpense', 'OtherNonoperatingIncomeExpense'],
+  },
+  pretaxIncome: {
+    statement: 'income',
+    label: 'Pre-Tax Income',
+    unit: 'USD',
+    tags: [
+      'IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest',
+      'IncomeLossFromContinuingOperationsBeforeIncomeTaxesMinorityInterestAndIncomeLossFromEquityMethodInvestments',
+    ],
+  },
+  incomeTaxExpense: {
+    statement: 'income',
+    label: 'Income Tax Expense',
+    unit: 'USD',
+    tags: ['IncomeTaxExpenseBenefit'],
+  },
   netIncome: {
+    statement: 'income',
+    label: 'Net Income',
     unit: 'USD',
-    tags: ['NetIncomeLoss'],
+    tags: ['NetIncomeLoss', 'ProfitLoss'],
   },
-  totalAssets: {
-    unit: 'USD',
-    tags: ['Assets'],
+
+  // ---- Per share ---------------------------------------------------------
+  epsBasic: {
+    statement: 'pershare',
+    label: 'EPS (Basic)',
+    unit: 'USD/shares',
+    tags: ['EarningsPerShareBasic'],
   },
-  currentAssets: {
-    unit: 'USD',
-    tags: ['AssetsCurrent'],
+  dilutedEPS: {
+    statement: 'pershare',
+    label: 'EPS (Diluted)',
+    unit: 'USD/shares',
+    tags: ['EarningsPerShareDiluted'],
   },
+  sharesBasic: {
+    statement: 'pershare',
+    label: 'Shares (Basic)',
+    unit: 'shares',
+    tags: ['WeightedAverageNumberOfSharesOutstandingBasic'],
+  },
+  dilutedShares: {
+    statement: 'pershare',
+    label: 'Shares (Diluted)',
+    unit: 'shares',
+    tags: ['WeightedAverageNumberOfDilutedSharesOutstanding'],
+  },
+  dividendsPerShare: {
+    statement: 'pershare',
+    label: 'Dividends per Share',
+    unit: 'USD/shares',
+    tags: ['CommonStockDividendsPerShareDeclared', 'CommonStockDividendsPerShareCashPaid'],
+  },
+
+  // ---- Balance sheet -----------------------------------------------------
   cashAndEquivalents: {
+    statement: 'balance',
+    label: 'Cash & Equivalents',
     unit: 'USD',
     tags: [
       'CashAndCashEquivalentsAtCarryingValue',
       'CashCashEquivalentsRestrictedCashAndRestrictedCashEquivalents',
     ],
   },
-  totalLiabilities: {
+  shortTermInvestments: {
+    statement: 'balance',
+    label: 'Short-Term Investments',
     unit: 'USD',
-    // Direct tag only. A computed fallback (LiabilitiesCurrent +
-    // LiabilitiesNoncurrent) is applied in the normalizer when this is absent.
+    tags: ['ShortTermInvestments', 'MarketableSecuritiesCurrent', 'AvailableForSaleSecuritiesCurrent'],
+  },
+  accountsReceivable: {
+    statement: 'balance',
+    label: 'Accounts Receivable',
+    unit: 'USD',
+    tags: ['AccountsReceivableNetCurrent', 'ReceivablesNetCurrent'],
+  },
+  inventory: { statement: 'balance', label: 'Inventory', unit: 'USD', tags: ['InventoryNet'] },
+  otherCurrentAssets: {
+    statement: 'balance',
+    label: 'Other Current Assets',
+    unit: 'USD',
+    tags: ['OtherAssetsCurrent'],
+  },
+  currentAssets: {
+    statement: 'balance',
+    label: 'Total Current Assets',
+    unit: 'USD',
+    tags: ['AssetsCurrent'],
+  },
+  propertyPlantEquipmentNet: {
+    statement: 'balance',
+    label: 'PP&E, Net',
+    unit: 'USD',
+    tags: ['PropertyPlantAndEquipmentNet'],
+  },
+  goodwill: { statement: 'balance', label: 'Goodwill', unit: 'USD', tags: ['Goodwill'] },
+  intangibleAssets: {
+    statement: 'balance',
+    label: 'Intangible Assets',
+    unit: 'USD',
+    tags: ['IntangibleAssetsNetExcludingGoodwill', 'FiniteLivedIntangibleAssetsNet'],
+  },
+  totalAssets: { statement: 'balance', label: 'Total Assets', unit: 'USD', tags: ['Assets'] },
+  accountsPayable: {
+    statement: 'balance',
+    label: 'Accounts Payable',
+    unit: 'USD',
+    tags: ['AccountsPayableCurrent', 'AccountsPayableAndAccruedLiabilitiesCurrent'],
+  },
+  shortTermDebt: {
+    statement: 'balance',
+    label: 'Short-Term / Current Debt',
+    unit: 'USD',
+    tags: ['LongTermDebtCurrent', 'DebtCurrent', 'ShortTermBorrowings'],
+  },
+  deferredRevenueCurrent: {
+    statement: 'balance',
+    label: 'Deferred Revenue (Current)',
+    unit: 'USD',
+    tags: ['ContractWithCustomerLiabilityCurrent', 'DeferredRevenueCurrent'],
+  },
+  currentLiabilities: {
+    statement: 'balance',
+    label: 'Total Current Liabilities',
+    unit: 'USD',
+    tags: ['LiabilitiesCurrent'],
+  },
+  longTermDebt: {
+    statement: 'balance',
+    label: 'Long-Term Debt',
+    unit: 'USD',
+    tags: ['LongTermDebtNoncurrent', 'LongTermDebt'],
+  },
+  totalLiabilities: {
+    statement: 'balance',
+    label: 'Total Liabilities',
+    unit: 'USD',
+    // A computed fallback (LiabilitiesCurrent + LiabilitiesNoncurrent) is
+    // applied in the normalizer when this direct tag is absent.
     tags: ['Liabilities'],
   },
+  commonStockValue: {
+    statement: 'balance',
+    label: 'Common Stock',
+    unit: 'USD',
+    tags: ['CommonStockValue'],
+  },
+  additionalPaidInCapital: {
+    statement: 'balance',
+    label: 'Additional Paid-In Capital',
+    unit: 'USD',
+    tags: ['AdditionalPaidInCapital', 'AdditionalPaidInCapitalCommonStock'],
+  },
+  retainedEarnings: {
+    statement: 'balance',
+    label: 'Retained Earnings',
+    unit: 'USD',
+    tags: ['RetainedEarningsAccumulatedDeficit'],
+  },
+  treasuryStock: {
+    statement: 'balance',
+    label: 'Treasury Stock',
+    unit: 'USD',
+    tags: ['TreasuryStockValue', 'TreasuryStockCommonValue'],
+  },
+  accumulatedOCI: {
+    statement: 'balance',
+    label: 'Accumulated OCI',
+    unit: 'USD',
+    tags: ['AccumulatedOtherComprehensiveIncomeLossNetOfTax'],
+  },
   stockholdersEquity: {
+    statement: 'balance',
+    label: "Stockholders' Equity",
     unit: 'USD',
     tags: [
       'StockholdersEquity',
       'StockholdersEquityIncludingPortionAttributableToNoncontrollingInterest',
     ],
   },
-  operatingCashFlow: {
+
+  // ---- Cash flow ---------------------------------------------------------
+  depreciationAmortization: {
+    statement: 'cashflow',
+    label: 'Depreciation & Amortization',
     unit: 'USD',
-    tags: ['NetCashProvidedByUsedInOperatingActivities'],
+    tags: [
+      'DepreciationDepletionAndAmortization',
+      'DepreciationAmortizationAndAccretionNet',
+      'DepreciationAndAmortization',
+    ],
+  },
+  stockBasedCompensation: {
+    statement: 'cashflow',
+    label: 'Stock-Based Compensation',
+    unit: 'USD',
+    tags: ['ShareBasedCompensation'],
+  },
+  operatingCashFlow: {
+    statement: 'cashflow',
+    label: 'Operating Cash Flow',
+    unit: 'USD',
+    tags: [
+      'NetCashProvidedByUsedInOperatingActivities',
+      'NetCashProvidedByUsedInOperatingActivitiesContinuingOperations',
+    ],
   },
   capitalExpenditure: {
+    statement: 'cashflow',
+    label: 'Capital Expenditure',
     unit: 'USD',
-    tags: ['PaymentsToAcquirePropertyPlantAndEquipment'],
+    tags: ['PaymentsToAcquirePropertyPlantAndEquipment', 'PaymentsToAcquireProductiveAssets'],
   },
-  dilutedEPS: {
-    unit: 'USD/shares',
-    tags: ['EarningsPerShareDiluted'],
+  acquisitions: {
+    statement: 'cashflow',
+    label: 'Acquisitions, Net',
+    unit: 'USD',
+    tags: ['PaymentsToAcquireBusinessesNetOfCashAcquired'],
   },
-  dilutedShares: {
-    unit: 'shares',
-    tags: ['WeightedAverageNumberOfDilutedSharesOutstanding'],
+  investingCashFlow: {
+    statement: 'cashflow',
+    label: 'Investing Cash Flow',
+    unit: 'USD',
+    tags: [
+      'NetCashProvidedByUsedInInvestingActivities',
+      'NetCashProvidedByUsedInInvestingActivitiesContinuingOperations',
+    ],
+  },
+  debtIssued: {
+    statement: 'cashflow',
+    label: 'Debt Issued',
+    unit: 'USD',
+    tags: ['ProceedsFromIssuanceOfLongTermDebt'],
+  },
+  debtRepaid: {
+    statement: 'cashflow',
+    label: 'Debt Repaid',
+    unit: 'USD',
+    tags: ['RepaymentsOfLongTermDebt'],
+  },
+  stockRepurchased: {
+    statement: 'cashflow',
+    label: 'Stock Repurchased',
+    unit: 'USD',
+    tags: ['PaymentsForRepurchaseOfCommonStock'],
+  },
+  dividendsPaid: {
+    statement: 'cashflow',
+    label: 'Dividends Paid',
+    unit: 'USD',
+    tags: ['PaymentsOfDividendsCommonStock', 'PaymentsOfDividends'],
+  },
+  financingCashFlow: {
+    statement: 'cashflow',
+    label: 'Financing Cash Flow',
+    unit: 'USD',
+    tags: [
+      'NetCashProvidedByUsedInFinancingActivities',
+      'NetCashProvidedByUsedInFinancingActivitiesContinuingOperations',
+    ],
   },
 };

--- a/server/src/treasury.js
+++ b/server/src/treasury.js
@@ -1,0 +1,40 @@
+const config = require('./config');
+
+// Risk-free rate from the US Treasury Daily Par Yield Curve feed (free, no key).
+// The feed is XML; rather than add an XML dependency we extract the latest
+// 10-year rate (BC_10YEAR) with a regex. Falls back to a configured default.
+const TREASURY_BASE =
+  'https://home.treasury.gov/resource-center/data-chart-center/interest-rates/pages/xml';
+
+function treasuryUrl(year) {
+  return `${TREASURY_BASE}?data=daily_treasury_yield_curve&field_tdr_date_value=${year}`;
+}
+
+function parseLatest10Year(xml) {
+  if (!xml) return null;
+  // Each daily entry contains <d:BC_10YEAR>4.32</d:BC_10YEAR>. The feed is
+  // chronological, so the last match is the most recent business day.
+  const matches = [...xml.matchAll(/<d:BC_10YEAR>([\d.]+)<\/d:BC_10YEAR>/g)];
+  if (!matches.length) return null;
+  const last = Number(matches[matches.length - 1][1]);
+  return Number.isFinite(last) ? last / 100 : null; // percent -> decimal
+}
+
+function createTreasuryProvider({ client, fallback = config.riskFreeRateDefault } = {}) {
+  async function getRiskFreeRate(year = new Date().getUTCFullYear()) {
+    try {
+      const xml = await client.getText(treasuryUrl(year));
+      const rate = parseLatest10Year(xml);
+      if (rate != null) {
+        return { riskFreeRate: rate, source: 'us-treasury:10y-par-yield', year };
+      }
+    } catch (_) {
+      /* fall through to default */
+    }
+    return { riskFreeRate: fallback, source: 'default', year };
+  }
+
+  return { getRiskFreeRate };
+}
+
+module.exports = { createTreasuryProvider, parseLatest10Year };

--- a/server/src/wacc.js
+++ b/server/src/wacc.js
@@ -1,0 +1,103 @@
+// WACC computation.
+//
+//   WACC = (E/V) * Re + (D/V) * Rd * (1 - Tc)
+//   Re   = Rf + Beta * ERP                (CAPM cost of equity)
+//
+// SEC supplies: cost of debt (interest / debt), effective tax rate, book debt.
+// Market data supplies: beta, market value of equity (market cap).
+// Treasury supplies: risk-free rate. ERP is an assumption.
+//
+// Every input is overridable so students can apply their own assumptions.
+
+function num(v) {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+
+// Effective tax rate, clamped to a sane 0–50% band.
+function effectiveTaxRate(period) {
+  const tax = num(period.incomeTaxExpense);
+  const pretax = num(period.pretaxIncome);
+  if (tax == null || pretax == null || pretax === 0) return null;
+  const rate = tax / pretax;
+  if (!Number.isFinite(rate)) return null;
+  return Math.min(Math.max(rate, 0), 0.5);
+}
+
+function computeWacc({ period, beta, marketCap, riskFreeRate, equityRiskPremium, overrides = {} }) {
+  const o = overrides;
+
+  const totalDebtBook = (num(period.shortTermDebt) || 0) + (num(period.longTermDebt) || 0) || null;
+  const totalDebt = num(o.totalDebt) != null ? o.totalDebt : totalDebtBook;
+  const interestExpense = num(period.interestExpense);
+
+  const costOfDebtPreTax =
+    num(o.costOfDebt) != null
+      ? o.costOfDebt
+      : interestExpense != null && totalDebt
+        ? interestExpense / totalDebt
+        : null;
+
+  const taxRate = num(o.taxRate) != null ? o.taxRate : effectiveTaxRate(period);
+  const rf = num(o.riskFreeRate) != null ? o.riskFreeRate : num(riskFreeRate);
+  const b = num(o.beta) != null ? o.beta : num(beta);
+  const erp = num(o.equityRiskPremium) != null ? o.equityRiskPremium : num(equityRiskPremium);
+  const equityMV = num(o.marketCap) != null ? o.marketCap : num(marketCap);
+
+  const costOfEquity = rf != null && b != null && erp != null ? rf + b * erp : null;
+  const afterTaxCostOfDebt =
+    costOfDebtPreTax != null && taxRate != null ? costOfDebtPreTax * (1 - taxRate) : null;
+
+  let weightEquity = null;
+  let weightDebt = null;
+  let wacc = null;
+  if (equityMV != null && totalDebt != null && equityMV + totalDebt > 0) {
+    const v = equityMV + totalDebt;
+    weightEquity = equityMV / v;
+    weightDebt = totalDebt / v;
+    if (costOfEquity != null && afterTaxCostOfDebt != null) {
+      wacc = weightEquity * costOfEquity + weightDebt * afterTaxCostOfDebt;
+    }
+  }
+
+  const missing = [];
+  if (b == null) missing.push('beta');
+  if (equityMV == null) missing.push('marketCap');
+  if (rf == null) missing.push('riskFreeRate');
+  if (erp == null) missing.push('equityRiskPremium');
+  if (costOfDebtPreTax == null) missing.push('costOfDebt');
+  if (taxRate == null) missing.push('taxRate');
+
+  return {
+    wacc,
+    components: {
+      costOfEquity,
+      costOfDebtPreTax,
+      afterTaxCostOfDebt,
+      taxRate,
+      weightEquity,
+      weightDebt,
+    },
+    inputs: {
+      fiscalYear: period.fiscalYear,
+      beta: b,
+      riskFreeRate: rf,
+      equityRiskPremium: erp,
+      marketValueOfEquity: equityMV,
+      totalDebt,
+      interestExpense,
+    },
+    sources: {
+      beta: 'market-data',
+      marketValueOfEquity: 'market-data',
+      riskFreeRate: 'us-treasury',
+      equityRiskPremium: 'assumption',
+      costOfDebt: 'sec (interestExpense / totalDebt)',
+      taxRate: 'sec (incomeTaxExpense / pretaxIncome)',
+      totalDebt: 'sec (book: short-term + long-term debt)',
+    },
+    missing,
+    complete: missing.length === 0 && wacc != null,
+  };
+}
+
+module.exports = { computeWacc, effectiveTaxRate };

--- a/server/src/wacc.js
+++ b/server/src/wacc.js
@@ -23,7 +23,7 @@ function effectiveTaxRate(period) {
   return Math.min(Math.max(rate, 0), 0.5);
 }
 
-function computeWacc({ period, beta, marketCap, riskFreeRate, equityRiskPremium, overrides = {} }) {
+function computeWacc({ period, beta, marketCap, bookEquity, riskFreeRate, equityRiskPremium, overrides = {} }) {
   const o = overrides;
 
   const totalDebtBook = (num(period.shortTermDebt) || 0) + (num(period.longTermDebt) || 0) || null;
@@ -41,7 +41,11 @@ function computeWacc({ period, beta, marketCap, riskFreeRate, equityRiskPremium,
   const rf = num(o.riskFreeRate) != null ? o.riskFreeRate : num(riskFreeRate);
   const b = num(o.beta) != null ? o.beta : num(beta);
   const erp = num(o.equityRiskPremium) != null ? o.equityRiskPremium : num(equityRiskPremium);
-  const equityMV = num(o.marketCap) != null ? o.marketCap : num(marketCap);
+  // Equity value for the weight: true market cap if available, else fall back to
+  // book equity so WACC still computes (flagged via equityBasis).
+  const trueMarketCap = num(o.marketCap) != null ? o.marketCap : num(marketCap);
+  const equityMV = trueMarketCap != null ? trueMarketCap : num(bookEquity);
+  const equityBasis = trueMarketCap != null ? 'market' : num(bookEquity) != null ? 'book' : null;
 
   const costOfEquity = rf != null && b != null && erp != null ? rf + b * erp : null;
   const afterTaxCostOfDebt =
@@ -61,7 +65,7 @@ function computeWacc({ period, beta, marketCap, riskFreeRate, equityRiskPremium,
 
   const missing = [];
   if (b == null) missing.push('beta');
-  if (equityMV == null) missing.push('marketCap');
+  if (equityMV == null) missing.push('equity');
   if (rf == null) missing.push('riskFreeRate');
   if (erp == null) missing.push('equityRiskPremium');
   if (costOfDebtPreTax == null) missing.push('costOfDebt');
@@ -82,7 +86,9 @@ function computeWacc({ period, beta, marketCap, riskFreeRate, equityRiskPremium,
       beta: b,
       riskFreeRate: rf,
       equityRiskPremium: erp,
-      marketValueOfEquity: equityMV,
+      marketValueOfEquity: trueMarketCap,
+      equityUsed: equityMV,
+      equityBasis,
       totalDebt,
       interestExpense,
     },

--- a/server/test/balanceSheet.test.js
+++ b/server/test/balanceSheet.test.js
@@ -1,0 +1,55 @@
+const { buildScheduleIII } = require('../src/balanceSheet');
+
+const lineValue = (s, key) => s.lines.find((l) => l.key === key).value;
+
+describe('buildScheduleIII', () => {
+  // A balanced, fully-mapped period.
+  const period = {
+    fiscalYear: 2024,
+    totalAssets: 1000, currentAssets: 400, totalLiabilities: 600, currentLiabilities: 250,
+    stockholdersEquity: 400,
+    cashAndEquivalents: 300, shortTermInvestments: 50,
+    propertyPlantEquipmentNet: 200, intangibleAssets: 100,
+    longTermDebt: 300, accountsPayable: 100, shortTermDebt: 50,
+    commonStockValue: 120, retainedEarnings: 300, treasuryStock: -20, accumulatedOCI: 0,
+  };
+  const s = buildScheduleIII(period);
+
+  test('balances: Total Assets = Total Equity and Liabilities', () => {
+    expect(lineValue(s, 'asTotal')).toBe(1000);
+    expect(lineValue(s, 'elTotal')).toBe(1000);
+    expect(s.balances).toBe(true);
+    expect(s.difference).toBe(0);
+  });
+
+  test('residual "Other" lines absorb unmapped amounts so groups reconcile', () => {
+    // Non-current assets = 1000-400 = 600; mapped 200+100 -> other 300
+    expect(lineValue(s, 'otherNonCurrentAssets')).toBe(300);
+    // Current assets = 400; mapped 300+50 -> other 50
+    expect(lineValue(s, 'otherCurrentAssets')).toBe(50);
+    // Non-current liab = 600-250 = 350; mapped 300 -> other 50
+    expect(lineValue(s, 'otherLongTermLiabilities')).toBe(50);
+    // Current liab = 250; mapped 50+100 -> other 100
+    expect(lineValue(s, 'otherCurrentLiabilities')).toBe(100);
+  });
+
+  test('splits equity into share capital and reserves', () => {
+    expect(lineValue(s, 'shareCapital')).toBe(120);
+    expect(lineValue(s, 'reserves')).toBe(280); // 400 - 120
+    expect(lineValue(s, 'otherReserves')).toBe(0); // 280 - (300 - 20 + 0)
+    expect(lineValue(s, 'sfTotal')).toBe(400);
+  });
+
+  test('subtotals tie to the SEC control totals', () => {
+    expect(lineValue(s, 'ncaTotal')).toBe(600);
+    expect(lineValue(s, 'caTotal')).toBe(400);
+    expect(lineValue(s, 'nclTotal')).toBe(350);
+    expect(lineValue(s, 'clTotal')).toBe(250);
+  });
+
+  test('handles missing control totals without throwing', () => {
+    const sparse = buildScheduleIII({ fiscalYear: 2024, totalAssets: 500, cashAndEquivalents: 100 });
+    expect(sparse.lines.length).toBeGreaterThan(0);
+    expect(lineValue(sparse, 'asTotal')).toBe(500);
+  });
+});

--- a/server/test/cikLookup.test.js
+++ b/server/test/cikLookup.test.js
@@ -1,0 +1,45 @@
+const { padCik, cikUrlParam, findTickerEntry } = require('../src/cikLookup');
+const { tickers } = require('./fixtures/secFixtures');
+
+describe('padCik', () => {
+  test('pads a numeric CIK to 10 digits', () => {
+    expect(padCik(1065280)).toBe('0001065280');
+  });
+
+  test('accepts a string CIK', () => {
+    expect(padCik('320193')).toBe('0000320193');
+  });
+
+  test('leaves an already-padded CIK unchanged', () => {
+    expect(padCik('0001065280')).toBe('0001065280');
+  });
+
+  test('strips non-digit characters', () => {
+    expect(padCik('CIK0001065280')).toBe('0001065280');
+  });
+
+  test('throws on a non-numeric CIK', () => {
+    expect(() => padCik('abc')).toThrow();
+  });
+});
+
+describe('cikUrlParam', () => {
+  test('produces the data.sec.gov path segment', () => {
+    expect(cikUrlParam(1065280)).toBe('CIK0001065280');
+  });
+});
+
+describe('findTickerEntry', () => {
+  test('finds a ticker case-insensitively', () => {
+    expect(findTickerEntry(tickers, 'nflx')).toMatchObject({ cik_str: 1065280, ticker: 'NFLX' });
+  });
+
+  test('returns null for an unknown ticker', () => {
+    expect(findTickerEntry(tickers, 'NOPE')).toBeNull();
+  });
+
+  test('returns null for empty input', () => {
+    expect(findTickerEntry(tickers, '')).toBeNull();
+    expect(findTickerEntry(null, 'NFLX')).toBeNull();
+  });
+});

--- a/server/test/damodaran.test.js
+++ b/server/test/damodaran.test.js
@@ -1,0 +1,40 @@
+const { getIndustryBeta, sicToIndustry, relever } = require('../src/damodaran');
+
+describe('sicToIndustry', () => {
+  test('maps Netflix SIC 7841 to Entertainment', () => {
+    expect(sicToIndustry('7841')).toBe('Entertainment');
+  });
+  test('maps a software SIC to Software', () => {
+    expect(sicToIndustry('7372')).toBe('Software (System & Application)');
+  });
+  test('returns null for unknown SIC', () => {
+    expect(sicToIndustry('9999')).toBeNull();
+    expect(sicToIndustry('')).toBeNull();
+  });
+});
+
+describe('relever', () => {
+  test('beta_L = beta_U * (1 + (1 - t) * D/E)', () => {
+    expect(relever(1.0, { de: 0.5, taxRate: 0.2 })).toBeCloseTo(1.4, 6);
+  });
+  test('returns the unlevered beta when D/E is unknown', () => {
+    expect(relever(1.1, { de: null, taxRate: 0.2 })).toBe(1.1);
+  });
+});
+
+describe('getIndustryBeta', () => {
+  test('relevers the matched industry asset beta', () => {
+    const r = getIndustryBeta({ sic: '7841', de: 0.5, taxRate: 0.2 });
+    expect(r.industry).toBe('Entertainment');
+    expect(r.matchedBy).toBe('sic');
+    expect(r.unleveredBeta).toBe(1.1);
+    expect(r.releveredBeta).toBeCloseTo(1.1 * 1.4, 6); // 1.54
+  });
+
+  test('falls back to Total Market for unknown industries', () => {
+    const r = getIndustryBeta({ sic: '9999', de: 0, taxRate: 0.2 });
+    expect(r.industry).toBe('Total Market');
+    expect(r.matchedBy).toBe('fallback');
+    expect(r.releveredBeta).toBe(r.unleveredBeta); // de = 0
+  });
+});

--- a/server/test/filingText.test.js
+++ b/server/test/filingText.test.js
@@ -1,0 +1,38 @@
+const { extractBusinessSection, htmlToText } = require('../src/filingText');
+
+describe('htmlToText', () => {
+  test('strips tags and decodes basic entities', () => {
+    expect(htmlToText('<p>Hello&nbsp;&amp; <b>world</b></p>')).toBe('Hello & world');
+  });
+});
+
+describe('extractBusinessSection', () => {
+  const html = `
+    <html><body>
+      <div>Table of contents</div>
+      <a>Item 1. Business .......... 4</a>
+      <a>Item 1A. Risk Factors ...... 12</a>
+      <h2>Item 1. Business</h2>
+      <p>Acme Corp designs and sells widgets to enterprise customers worldwide.</p>
+      <p>We operate one reportable segment.</p>
+      <h2>Item 1A. Risk Factors</h2>
+      <p>Our business faces competition and other risks.</p>
+    </body></html>`;
+
+  test('extracts the real Business section (not the TOC) and stops at Risk Factors', () => {
+    const r = extractBusinessSection(html);
+    expect(r.excerpt).toMatch(/Acme Corp designs and sells widgets/);
+    expect(r.excerpt).not.toMatch(/faces competition/); // stops before Risk Factors body
+  });
+
+  test('truncates long sections', () => {
+    const long = '<h2>Item 1. Business</h2><p>' + 'word '.repeat(2000) + '</p><h2>Item 1A. Risk Factors</h2>';
+    const r = extractBusinessSection(long, { maxChars: 500 });
+    expect(r.truncated).toBe(true);
+    expect(r.excerpt.length).toBeLessThanOrEqual(520);
+  });
+
+  test('returns null when there is no Business section', () => {
+    expect(extractBusinessSection('<p>nothing here</p>')).toBeNull();
+  });
+});

--- a/server/test/fixtures/inlineXbrl.js
+++ b/server/test/fixtures/inlineXbrl.js
@@ -73,5 +73,11 @@ module.exports = `<?xml version="1.0" encoding="UTF-8"?>
 <p>Product x geography intersection - must be excluded (multi-axis):
   <ix:nonFraction name="us-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"
     contextRef="cProdGeo2024" unitRef="usd" scale="3" decimals="-3">12000000</ix:nonFraction></p>
+
+<h2>Item 1. Business</h2>
+<p>SampleCo is a synthetic streaming entertainment company used for tests. We operate
+globally and earn subscription revenue across multiple regions.</p>
+<h2>Item 1A. Risk Factors</h2>
+<p>Our business is subject to numerous risks described in this section.</p>
 </body>
 </html>`;

--- a/server/test/fixtures/inlineXbrl.js
+++ b/server/test/fixtures/inlineXbrl.js
@@ -1,0 +1,77 @@
+// A trimmed, synthetic inline-XBRL document that mirrors how a real 10-K encodes
+// dimensional (segment / geographic / product) revenue facts. Used to test the
+// segment parser without hitting the network.
+//
+// scale="3" means the displayed value is value x 10^3 (reported in thousands).
+module.exports = `<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns:ix="http://www.xbrl.org/2013/inlineXBRL"
+      xmlns:xbrli="http://www.xbrl.org/2003/instance"
+      xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+<body>
+<ix:header><ix:resources>
+  <xbrli:context id="cProd2024Stream">
+    <xbrli:period><xbrli:startDate>2024-01-01</xbrli:startDate><xbrli:endDate>2024-12-31</xbrli:endDate></xbrli:period>
+    <xbrli:entity><xbrli:segment>
+      <xbrldi:explicitMember dimension="srt:ProductOrServiceAxis">nflx:StreamingRevenuesMember</xbrldi:explicitMember>
+    </xbrli:segment></xbrli:entity>
+  </xbrli:context>
+  <xbrli:context id="cProd2024DVD">
+    <xbrli:period><xbrli:startDate>2024-01-01</xbrli:startDate><xbrli:endDate>2024-12-31</xbrli:endDate></xbrli:period>
+    <xbrli:entity><xbrli:segment>
+      <xbrldi:explicitMember dimension="srt:ProductOrServiceAxis">nflx:DvdRevenuesMember</xbrldi:explicitMember>
+    </xbrli:segment></xbrli:entity>
+  </xbrli:context>
+  <xbrli:context id="cProd2023Stream">
+    <xbrli:period><xbrli:startDate>2023-01-01</xbrli:startDate><xbrli:endDate>2023-12-31</xbrli:endDate></xbrli:period>
+    <xbrli:entity><xbrli:segment>
+      <xbrldi:explicitMember dimension="srt:ProductOrServiceAxis">nflx:StreamingRevenuesMember</xbrldi:explicitMember>
+    </xbrli:segment></xbrli:entity>
+  </xbrli:context>
+  <xbrli:context id="cGeo2024US">
+    <xbrli:period><xbrli:startDate>2024-01-01</xbrli:startDate><xbrli:endDate>2024-12-31</xbrli:endDate></xbrli:period>
+    <xbrli:entity><xbrli:segment>
+      <xbrldi:explicitMember dimension="srt:StatementGeographicalAxis">country:US</xbrldi:explicitMember>
+    </xbrli:segment></xbrli:entity>
+  </xbrli:context>
+  <xbrli:context id="cConsolidated2024">
+    <xbrli:period><xbrli:startDate>2024-01-01</xbrli:startDate><xbrli:endDate>2024-12-31</xbrli:endDate></xbrli:period>
+    <xbrli:entity></xbrli:entity>
+  </xbrli:context>
+  <xbrli:context id="cProdQ12024">
+    <xbrli:period><xbrli:startDate>2024-01-01</xbrli:startDate><xbrli:endDate>2024-03-31</xbrli:endDate></xbrli:period>
+    <xbrli:entity><xbrli:segment>
+      <xbrldi:explicitMember dimension="srt:ProductOrServiceAxis">nflx:StreamingRevenuesMember</xbrldi:explicitMember>
+    </xbrli:segment></xbrli:entity>
+  </xbrli:context>
+  <xbrli:context id="cProdGeo2024">
+    <xbrli:period><xbrli:startDate>2024-01-01</xbrli:startDate><xbrli:endDate>2024-12-31</xbrli:endDate></xbrli:period>
+    <xbrli:entity><xbrli:segment>
+      <xbrldi:explicitMember dimension="srt:ProductOrServiceAxis">nflx:StreamingRevenuesMember</xbrldi:explicitMember>
+      <xbrldi:explicitMember dimension="srt:StatementGeographicalAxis">country:US</xbrldi:explicitMember>
+    </xbrli:segment></xbrli:entity>
+  </xbrli:context>
+</ix:resources></ix:header>
+
+<p>Streaming product revenue FY24:
+  <ix:nonFraction name="us-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"
+    contextRef="cProd2024Stream" unitRef="usd" scale="3" decimals="-3">38000000</ix:nonFraction></p>
+<p>DVD product revenue FY24:
+  <ix:nonFraction name="us-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"
+    contextRef="cProd2024DVD" unitRef="usd" scale="3" decimals="-3">1000000</ix:nonFraction></p>
+<p>Streaming product revenue FY23:
+  <ix:nonFraction name="us-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"
+    contextRef="cProd2023Stream" unitRef="usd" scale="3" decimals="-3">33000000</ix:nonFraction></p>
+<p>US geographic revenue FY24:
+  <ix:nonFraction name="us-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"
+    contextRef="cGeo2024US" unitRef="usd" scale="3" decimals="-3">15000000</ix:nonFraction></p>
+<p>Consolidated revenue (no segment) FY24 - must be excluded:
+  <ix:nonFraction name="us-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"
+    contextRef="cConsolidated2024" unitRef="usd" scale="3" decimals="-3">39000000</ix:nonFraction></p>
+<p>Q1 partial streaming revenue - must be excluded:
+  <ix:nonFraction name="us-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"
+    contextRef="cProdQ12024" unitRef="usd" scale="3" decimals="-3">9000000</ix:nonFraction></p>
+<p>Product x geography intersection - must be excluded (multi-axis):
+  <ix:nonFraction name="us-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"
+    contextRef="cProdGeo2024" unitRef="usd" scale="3" decimals="-3">12000000</ix:nonFraction></p>
+</body>
+</html>`;

--- a/server/test/fixtures/secFixtures.js
+++ b/server/test/fixtures/secFixtures.js
@@ -15,6 +15,25 @@ const submissions = {
   sic: '7841',
   sicDescription: 'Services-Video Tape Rental',
   fiscalYearEnd: '1231',
+  stateOfIncorporation: 'DE',
+  category: 'Large accelerated filer',
+  formerNames: [{ name: 'NETFLIX COM INC' }],
+  addresses: {
+    business: {
+      street1: '121 Albright Way',
+      city: 'Los Gatos',
+      stateOrCountry: 'CA',
+    },
+  },
+  filings: {
+    recent: {
+      form: ['10-K', '10-Q', '10-K'],
+      filingDate: ['2025-01-27', '2024-10-18', '2024-01-26'],
+      reportDate: ['2024-12-31', '2024-09-30', '2023-12-31'],
+      accessionNumber: ['A-2024', 'Q3-2024', 'A-2023'],
+      primaryDocument: ['nflx-20241231.htm', 'nflx-20240930.htm', 'nflx-20231231.htm'],
+    },
+  },
 };
 
 // Helper to keep fact entries terse.

--- a/server/test/fixtures/secFixtures.js
+++ b/server/test/fixtures/secFixtures.js
@@ -1,0 +1,139 @@
+// Hand-built fixtures that mirror the shape of the real SEC EDGAR JSON APIs,
+// crafted to exercise filtering, fallbacks, restatement handling and missing
+// data. Values are illustrative, not real Netflix figures.
+
+const tickers = {
+  0: { cik_str: 1065280, ticker: 'NFLX', title: 'NETFLIX INC' },
+  1: { cik_str: 320193, ticker: 'AAPL', title: 'Apple Inc.' },
+};
+
+const submissions = {
+  cik: '1065280',
+  name: 'NETFLIX INC',
+  tickers: ['NFLX'],
+  exchanges: ['NASDAQ'],
+  sic: '7841',
+  sicDescription: 'Services-Video Tape Rental',
+  fiscalYearEnd: '1231',
+};
+
+// Helper to keep fact entries terse.
+const dur = (start, end, val, fy, accn, filed, form = '10-K', fp = 'FY') => ({
+  start,
+  end,
+  val,
+  accn,
+  fy,
+  fp,
+  form,
+  filed,
+});
+const inst = (end, val, fy, accn, filed, form = '10-K', fp = 'FY') => ({
+  end,
+  val,
+  accn,
+  fy,
+  fp,
+  form,
+  filed,
+});
+
+const companyfacts = {
+  cik: 1065280,
+  entityName: 'NETFLIX INC',
+  facts: {
+    'us-gaap': {
+      Revenues: {
+        label: 'Revenues',
+        units: {
+          USD: [
+            dur('2022-01-01', '2022-12-31', 31616, 2022, 'A-2022', '2023-01-26'),
+            dur('2023-01-01', '2023-12-31', 33723, 2023, 'A-2023', '2024-01-26'),
+            // Restated comparative for 2023 inside the FY2024 10-K. The original
+            // (fy 2023) filing should win.
+            dur('2023-01-01', '2023-12-31', 33723, 2024, 'A-2024', '2025-01-27'),
+            // Quarterly 10-Q entry -> must be filtered out.
+            dur('2024-01-01', '2024-03-31', 9370, 2024, 'Q-2024', '2024-04-18', '10-Q', 'Q1'),
+            // Partial-year 10-K duration -> must be filtered out.
+            dur('2024-01-01', '2024-06-30', 18000, 2024, 'A-2024', '2025-01-27'),
+          ],
+        },
+      },
+      // 2024 full-year revenue only available under the newer tag -> fallback.
+      RevenueFromContractWithCustomerExcludingAssessedTax: {
+        units: {
+          USD: [dur('2024-01-01', '2024-12-31', 39000, 2024, 'A-2024', '2025-01-27')],
+        },
+      },
+      // CostOfRevenue absent entirely -> costOfRevenue must use the fallback tag.
+      CostOfGoodsAndServicesSold: {
+        units: {
+          USD: [
+            dur('2023-01-01', '2023-12-31', 19715, 2023, 'A-2023', '2024-01-26'),
+            dur('2024-01-01', '2024-12-31', 21038, 2024, 'A-2024', '2025-01-27'),
+          ],
+        },
+      },
+      OperatingIncomeLoss: {
+        units: {
+          USD: [dur('2024-01-01', '2024-12-31', 10000, 2024, 'A-2024', '2025-01-27')],
+        },
+      },
+      NetIncomeLoss: {
+        units: {
+          USD: [
+            dur('2022-01-01', '2022-12-31', 4492, 2022, 'A-2022', '2023-01-26'),
+            dur('2023-01-01', '2023-12-31', 5408, 2023, 'A-2023', '2024-01-26'),
+            dur('2024-01-01', '2024-12-31', 8712, 2024, 'A-2024', '2025-01-27'),
+          ],
+        },
+      },
+      Assets: {
+        units: {
+          USD: [
+            inst('2022-12-31', 48595, 2022, 'A-2022', '2023-01-26'),
+            inst('2023-12-31', 48732, 2023, 'A-2023', '2024-01-26'),
+            // Comparative restatement of 2023 inside FY2024 10-K.
+            inst('2023-12-31', 48732, 2024, 'A-2024', '2025-01-27'),
+            inst('2024-12-31', 53630, 2024, 'A-2024', '2025-01-27'),
+          ],
+        },
+      },
+      AssetsCurrent: {
+        units: { USD: [inst('2024-12-31', 9000, 2024, 'A-2024', '2025-01-27')] },
+      },
+      CashAndCashEquivalentsAtCarryingValue: {
+        units: { USD: [inst('2024-12-31', 7800, 2024, 'A-2024', '2025-01-27')] },
+      },
+      // No direct `Liabilities` tag -> must be derived from current + noncurrent.
+      LiabilitiesCurrent: {
+        units: { USD: [inst('2024-12-31', 10000, 2024, 'A-2024', '2025-01-27')] },
+      },
+      LiabilitiesNoncurrent: {
+        units: { USD: [inst('2024-12-31', 18000, 2024, 'A-2024', '2025-01-27')] },
+      },
+      StockholdersEquity: {
+        units: { USD: [inst('2024-12-31', 24743, 2024, 'A-2024', '2025-01-27')] },
+      },
+      NetCashProvidedByUsedInOperatingActivities: {
+        units: { USD: [dur('2024-01-01', '2024-12-31', 7000, 2024, 'A-2024', '2025-01-27')] },
+      },
+      PaymentsToAcquirePropertyPlantAndEquipment: {
+        units: { USD: [dur('2024-01-01', '2024-12-31', 300, 2024, 'A-2024', '2025-01-27')] },
+      },
+      EarningsPerShareDiluted: {
+        units: {
+          'USD/shares': [dur('2024-01-01', '2024-12-31', 19.83, 2024, 'A-2024', '2025-01-27')],
+        },
+      },
+      WeightedAverageNumberOfDilutedSharesOutstanding: {
+        units: {
+          shares: [dur('2024-01-01', '2024-12-31', 439000000, 2024, 'A-2024', '2025-01-27')],
+        },
+      },
+      // GrossProfit intentionally absent -> field stays null.
+    },
+  },
+};
+
+module.exports = { tickers, submissions, companyfacts };

--- a/server/test/fixtures/secFixtures.js
+++ b/server/test/fixtures/secFixtures.js
@@ -152,6 +152,11 @@ const companyfacts = {
       },
       // GrossProfit intentionally absent -> field stays null.
     },
+    dei: {
+      EntityCommonStockSharesOutstanding: {
+        units: { shares: [{ end: '2025-01-15', val: 430000000, fy: 2024, fp: 'FY', form: '10-K' }] },
+      },
+    },
   },
 };
 

--- a/server/test/incomeStatement.test.js
+++ b/server/test/incomeStatement.test.js
@@ -1,0 +1,49 @@
+const { buildScheduleIIIPL } = require('../src/incomeStatement');
+
+const val = (s, key) => s.lines.find((l) => l.key === key).value;
+
+describe('buildScheduleIIIPL', () => {
+  const period = {
+    fiscalYear: 2024,
+    revenue: 1000, interestIncome: 20, otherIncomeExpense: 10,
+    pretaxIncome: 300, costOfRevenue: 500, interestExpense: 30,
+    incomeTaxExpense: 60, deferredIncomeTaxes: 10, netIncome: 240,
+    epsBasic: 2.4, dilutedEPS: 2.35,
+  };
+  const s = buildScheduleIIIPL(period);
+
+  test('Total Income − Total Expenses reconciles to Profit Before Tax', () => {
+    expect(val(s, 'ti')).toBe(1030); // 1000 + 30 other income
+    expect(val(s, 'te')).toBe(730); // 1030 − 300
+    expect(val(s, 'pbt')).toBe(300);
+    expect(s.balances).toBe(true);
+  });
+
+  test('Other expenses absorb the functional operating costs', () => {
+    // 730 total − 500 cost of revenue − 30 finance costs = 200
+    expect(val(s, 'oe')).toBe(200);
+  });
+
+  test('splits tax into current and deferred', () => {
+    expect(val(s, 'dt')).toBe(10);
+    expect(val(s, 'ct')).toBe(50); // 60 − 10
+    expect(val(s, 'tt')).toBe(60);
+  });
+
+  test('flows PBT → PAT → profit for the period', () => {
+    expect(val(s, 'pat')).toBe(240); // 300 − 60
+    expect(val(s, 'oth')).toBe(0); // 240 − 240
+    expect(val(s, 'pfp')).toBe(240);
+  });
+
+  test('EPS lines are per-share', () => {
+    const epsb = s.lines.find((l) => l.key === 'epsb');
+    expect(epsb.value).toBe(2.4);
+    expect(epsb.unit).toBe('USD/shares');
+  });
+
+  test('falls back to net income + tax when PBT is not reported', () => {
+    const s2 = buildScheduleIIIPL({ fiscalYear: 2024, revenue: 100, netIncome: 60, incomeTaxExpense: 15 });
+    expect(val(s2, 'pbt')).toBe(75);
+  });
+});

--- a/server/test/normalize.test.js
+++ b/server/test/normalize.test.js
@@ -1,4 +1,8 @@
-const { normalizeCompanyFacts, isFullYearDuration } = require('../src/normalize');
+const {
+  normalizeCompanyFacts,
+  isFullYearDuration,
+  extractAllAnnualFacts,
+} = require('../src/normalize');
 const { companyfacts } = require('./fixtures/secFixtures');
 
 describe('isFullYearDuration', () => {
@@ -110,5 +114,43 @@ describe('normalizeCompanyFacts', () => {
     const empty = normalizeCompanyFacts({ entityName: 'X', facts: {} });
     expect(empty.periods).toEqual([]);
     expect(empty.companyName).toBe('X');
+  });
+
+  test('maps newly added line items (current liabilities, R&D fallbacks)', () => {
+    // LiabilitiesCurrent in the fixture now also surfaces as currentLiabilities.
+    expect(byYear[2024].currentLiabilities).toBe(10000);
+    expect(byYear[2024].rawTagsUsed.currentLiabilities.tag).toBe('LiabilitiesCurrent');
+  });
+});
+
+describe('extractAllAnnualFacts', () => {
+  const all = extractAllAnnualFacts(companyfacts);
+
+  test('returns every reported annual concept', () => {
+    const tags = all.concepts.map((c) => c.tag);
+    expect(tags).toEqual(expect.arrayContaining(['Revenues', 'NetIncomeLoss', 'Assets']));
+    expect(all.conceptCount).toBe(all.concepts.length);
+    expect(all.taxonomy).toBe('us-gaap');
+  });
+
+  test('concepts are sorted and carry a per-year audit trail', () => {
+    const sorted = [...all.concepts].sort((a, b) => a.tag.localeCompare(b.tag));
+    expect(all.concepts.map((c) => c.tag)).toEqual(sorted.map((c) => c.tag));
+    const revenue = all.concepts.find((c) => c.tag === 'Revenues');
+    expect(revenue.values[2023]).toMatchObject({ value: 33723, unit: 'USD', form: '10-K' });
+  });
+
+  test('excludes 10-Q / partial periods (Revenues 2024 partials dropped)', () => {
+    const revenue = all.concepts.find((c) => c.tag === 'Revenues');
+    // Only the full-year 2022/2023 entries survive under Revenues.
+    expect(Object.keys(revenue.values).map(Number).sort()).toEqual([2022, 2023]);
+  });
+
+  test('respects the years limit', () => {
+    const limited = extractAllAnnualFacts(companyfacts, { years: 1 });
+    expect(limited.fiscalYears).toEqual([2024]);
+    for (const c of limited.concepts) {
+      expect(Object.keys(c.values).map(Number).every((y) => y === 2024)).toBe(true);
+    }
   });
 });

--- a/server/test/normalize.test.js
+++ b/server/test/normalize.test.js
@@ -1,0 +1,114 @@
+const { normalizeCompanyFacts, isFullYearDuration } = require('../src/normalize');
+const { companyfacts } = require('./fixtures/secFixtures');
+
+describe('isFullYearDuration', () => {
+  test('accepts a ~365 day period', () => {
+    expect(isFullYearDuration({ start: '2024-01-01', end: '2024-12-31' })).toBe(true);
+  });
+  test('rejects a quarterly period', () => {
+    expect(isFullYearDuration({ start: '2024-01-01', end: '2024-03-31' })).toBe(false);
+  });
+  test('rejects an instant fact (no start)', () => {
+    expect(isFullYearDuration({ end: '2024-12-31' })).toBe(false);
+  });
+});
+
+describe('normalizeCompanyFacts', () => {
+  const result = normalizeCompanyFacts(companyfacts);
+  const byYear = Object.fromEntries(result.periods.map((p) => [p.fiscalYear, p]));
+
+  test('returns periods sorted newest-first', () => {
+    expect(result.periods.map((p) => p.fiscalYear)).toEqual([2024, 2023, 2022]);
+  });
+
+  test('uses the company entity name', () => {
+    expect(result.companyName).toBe('NETFLIX INC');
+  });
+
+  test('every period is an annual 10-K', () => {
+    for (const p of result.periods) {
+      expect(p.form).toBe('10-K');
+    }
+  });
+
+  test('filters out 10-Q and partial-year durations', () => {
+    // Only full-year FY values survive; the Q1 and H1 Revenues entries are gone.
+    expect(byYear[2024].revenue).toBe(39000); // from fallback tag, not 9370/18000
+    expect(byYear[2023].revenue).toBe(33723);
+    expect(byYear[2022].revenue).toBe(31616);
+  });
+
+  test('applies fallback tag when the primary tag lacks the year', () => {
+    expect(byYear[2024].rawTagsUsed.revenue.tag).toBe(
+      'RevenueFromContractWithCustomerExcludingAssessedTax'
+    );
+    expect(byYear[2023].rawTagsUsed.revenue.tag).toBe('Revenues');
+  });
+
+  test('uses fallback tag for cost of revenue', () => {
+    expect(byYear[2024].costOfRevenue).toBe(21038);
+    expect(byYear[2024].rawTagsUsed.costOfRevenue.tag).toBe('CostOfGoodsAndServicesSold');
+  });
+
+  test('derives total liabilities from current + noncurrent when direct tag missing', () => {
+    expect(byYear[2024].totalLiabilities).toBe(28000);
+    const audit = byYear[2024].rawTagsUsed.totalLiabilities;
+    expect(audit.tag).toBe('LiabilitiesCurrent+LiabilitiesNoncurrent');
+    expect(audit.derived).toBe(true);
+    // No data for earlier years -> stays null.
+    expect(byYear[2023].totalLiabilities).toBeNull();
+  });
+
+  test('leaves unmapped/absent fields null', () => {
+    expect(byYear[2024].grossProfit).toBeNull();
+    expect(byYear[2024].rawTagsUsed.grossProfit).toBeUndefined();
+  });
+
+  test('prefers the original filing over a restated comparative', () => {
+    // 2023 Assets exist in both the FY2023 (A-2023) and FY2024 (A-2024) filings.
+    expect(byYear[2023].rawTagsUsed.totalAssets.accessionNumber).toBe('A-2023');
+    expect(byYear[2023].rawTagsUsed.totalAssets.reportFiscalYear).toBe(2023);
+  });
+
+  test('records full audit trail per value', () => {
+    const audit = byYear[2024].rawTagsUsed.netIncome;
+    expect(audit).toMatchObject({
+      tag: 'NetIncomeLoss',
+      unit: 'USD',
+      fiscalYear: 2024,
+      accessionNumber: 'A-2024',
+      filed: '2025-01-27',
+      form: '10-K',
+      periodEnd: '2024-12-31',
+    });
+  });
+
+  test('handles non-USD units for EPS and shares', () => {
+    expect(byYear[2024].dilutedEPS).toBe(19.83);
+    expect(byYear[2024].rawTagsUsed.dilutedEPS.unit).toBe('USD/shares');
+    expect(byYear[2024].dilutedShares).toBe(439000000);
+    expect(byYear[2024].rawTagsUsed.dilutedShares.unit).toBe('shares');
+  });
+
+  test('period-level filed/accession come from the period\'s own 10-K', () => {
+    expect(byYear[2024].filed).toBe('2025-01-27');
+    expect(byYear[2024].accessionNumber).toBe('A-2024');
+    expect(byYear[2023].accessionNumber).toBe('A-2023');
+  });
+
+  test('limits to the latest N periods when years is given', () => {
+    const limited = normalizeCompanyFacts(companyfacts, { years: 2 });
+    expect(limited.periods.map((p) => p.fiscalYear)).toEqual([2024, 2023]);
+  });
+
+  test('ignores an invalid years value', () => {
+    const all = normalizeCompanyFacts(companyfacts, { years: 'abc' });
+    expect(all.periods).toHaveLength(3);
+  });
+
+  test('handles companyfacts with no us-gaap data', () => {
+    const empty = normalizeCompanyFacts({ entityName: 'X', facts: {} });
+    expect(empty.periods).toEqual([]);
+    expect(empty.companyName).toBe('X');
+  });
+});

--- a/server/test/normalize.test.js
+++ b/server/test/normalize.test.js
@@ -64,8 +64,16 @@ describe('normalizeCompanyFacts', () => {
   });
 
   test('leaves unmapped/absent fields null', () => {
-    expect(byYear[2024].grossProfit).toBeNull();
-    expect(byYear[2024].rawTagsUsed.grossProfit).toBeUndefined();
+    expect(byYear[2024].goodwill).toBeNull();
+    expect(byYear[2024].rawTagsUsed.goodwill).toBeUndefined();
+  });
+
+  test('derives gross profit when GrossProfit is not tagged', () => {
+    // FY2024: revenue 39000 (fallback tag) - costOfRevenue 21038 = 17962
+    expect(byYear[2024].grossProfit).toBe(39000 - 21038);
+    expect(byYear[2024].rawTagsUsed.grossProfit.derived).toBe(true);
+    // FY2022 has revenue but no cost of revenue -> stays null
+    expect(byYear[2022].grossProfit).toBeNull();
   });
 
   test('prefers the original filing over a restated comparative', () => {
@@ -120,6 +128,54 @@ describe('normalizeCompanyFacts', () => {
     // LiabilitiesCurrent in the fixture now also surfaces as currentLiabilities.
     expect(byYear[2024].currentLiabilities).toBe(10000);
     expect(byYear[2024].rawTagsUsed.currentLiabilities.tag).toBe('LiabilitiesCurrent');
+  });
+});
+
+describe('split / restatement handling', () => {
+  const dur = (start, end, val, fy, accn, filed) => ({ start, end, val, fy, fp: 'FY', form: '10-K', accn, filed });
+  const facts = {
+    entityName: 'SplitCo',
+    facts: {
+      'us-gaap': {
+        WeightedAverageNumberOfDilutedSharesOutstanding: {
+          units: {
+            shares: [
+              dur('2025-01-01', '2025-12-31', 4400000000, 2025, 'A25', '2026-01-20'),
+              dur('2024-01-01', '2024-12-31', 4400000000, 2025, 'A25', '2026-01-20'), // restated post-split
+              dur('2024-01-01', '2024-12-31', 440000000, 2024, 'A24', '2025-01-20'), // original pre-split
+              dur('2023-01-01', '2023-12-31', 4400000000, 2025, 'A25', '2026-01-20'),
+              dur('2022-01-01', '2022-12-31', 450000000, 2024, 'A24', '2025-01-20'),
+            ],
+          },
+        },
+      },
+    },
+  };
+  const result = normalizeCompanyFacts(facts);
+  const byYear = Object.fromEntries(result.periods.map((p) => [p.fiscalYear, p]));
+
+  test('uses the latest restated (split-adjusted) value for prior years', () => {
+    expect(byYear[2024].dilutedShares).toBe(4400000000); // not the original 440M
+  });
+
+  test('flags a likely stock-split discontinuity', () => {
+    expect(result.warnings.some((w) => /stock split/i.test(w))).toBe(true);
+  });
+});
+
+describe('treasury stock sign', () => {
+  const facts = {
+    entityName: 'T',
+    facts: {
+      'us-gaap': {
+        TreasuryStockValue: {
+          units: { USD: [{ end: '2024-12-31', val: 13000000000, fy: 2024, fp: 'FY', form: '10-K', accn: 'A', filed: '2025-01-20' }] },
+        },
+      },
+    },
+  };
+  test('normalizes treasury stock to a negative contra value', () => {
+    expect(normalizeCompanyFacts(facts).periods[0].treasuryStock).toBe(-13000000000);
   });
 });
 

--- a/server/test/priceData.test.js
+++ b/server/test/priceData.test.js
@@ -13,18 +13,24 @@ describe('parseStooqCsv', () => {
 });
 
 describe('createPriceProvider', () => {
-  test('requests the Stooq CSV endpoint and parses the close', async () => {
+  test('requests the Stooq CSV endpoint with a browser UA and parses the close', async () => {
     let requested = null;
-    const client = {
-      getText: async (url) => {
-        requested = url;
-        return 'Symbol,Date,Time,Open,High,Low,Close,Volume\nNFLX.US,2026-05-26,22:00,1,1,1,1234.5,1';
-      },
+    let ua = null;
+    const fetchImpl = async (url, opts) => {
+      requested = url;
+      ua = opts.headers['User-Agent'];
+      return { ok: true, text: async () => 'Symbol,Date,Time,Open,High,Low,Close,Volume\nNFLX.US,2026-05-26,22:00,1,1,1,1234.5,1' };
     };
-    const provider = createPriceProvider({ client });
+    const provider = createPriceProvider({ fetchImpl });
     const close = await provider.getClose('NFLX');
     expect(close).toBe(1234.5);
     expect(requested).toContain('nflx.us');
     expect(requested).toContain('e=csv');
+    expect(ua).toMatch(/Mozilla/);
+  });
+
+  test('returns null on a non-OK response', async () => {
+    const provider = createPriceProvider({ fetchImpl: async () => ({ ok: false, text: async () => '' }) });
+    expect(await provider.getClose('NFLX')).toBeNull();
   });
 });

--- a/server/test/priceData.test.js
+++ b/server/test/priceData.test.js
@@ -1,0 +1,30 @@
+const { parseStooqCsv, createPriceProvider } = require('../src/priceData');
+
+describe('parseStooqCsv', () => {
+  test('extracts the close price', () => {
+    const csv = 'Symbol,Date,Time,Open,High,Low,Close,Volume\nAAPL.US,2026-05-26,22:00:05,270,275,269,272.5,40000000';
+    expect(parseStooqCsv(csv)).toBe(272.5);
+  });
+  test('returns null for N/D or malformed data', () => {
+    expect(parseStooqCsv('Symbol,Date,Time,Open,High,Low,Close,Volume\nFOO.US,N/D,N/D,N/D,N/D,N/D,N/D,N/D')).toBeNull();
+    expect(parseStooqCsv('')).toBeNull();
+    expect(parseStooqCsv('no header')).toBeNull();
+  });
+});
+
+describe('createPriceProvider', () => {
+  test('requests the Stooq CSV endpoint and parses the close', async () => {
+    let requested = null;
+    const client = {
+      getText: async (url) => {
+        requested = url;
+        return 'Symbol,Date,Time,Open,High,Low,Close,Volume\nNFLX.US,2026-05-26,22:00,1,1,1,1234.5,1';
+      },
+    };
+    const provider = createPriceProvider({ client });
+    const close = await provider.getClose('NFLX');
+    expect(close).toBe(1234.5);
+    expect(requested).toContain('nflx.us');
+    expect(requested).toContain('e=csv');
+  });
+});

--- a/server/test/profile.test.js
+++ b/server/test/profile.test.js
@@ -1,0 +1,43 @@
+const { buildProfile } = require('../src/profile');
+const { normalizeCompanyFacts } = require('../src/normalize');
+const { submissions, companyfacts } = require('./fixtures/secFixtures');
+
+describe('buildProfile', () => {
+  const modelData = normalizeCompanyFacts(companyfacts, { years: 5 });
+  const profile = buildProfile({ ticker: 'NFLX', cik: '0001065280', submissions, modelData });
+
+  test('carries SEC submissions metadata', () => {
+    expect(profile).toMatchObject({
+      ticker: 'NFLX',
+      cik: '0001065280',
+      name: 'NETFLIX INC',
+      industry: 'Services-Video Tape Rental',
+      sicCode: '7841',
+      stateOfIncorporation: 'DE',
+      exchanges: ['NASDAQ'],
+    });
+    expect(profile.headquarters).toMatchObject({ city: 'Los Gatos', state: 'CA' });
+    expect(profile.formerNames).toContain('NETFLIX COM INC');
+  });
+
+  test('computes a financial snapshot from the latest period', () => {
+    const s = profile.snapshot;
+    expect(s.fiscalYear).toBe(2024);
+    expect(s.revenue).toBe(39000); // fixture FY2024 revenue (fallback tag)
+    expect(s.netMargin).toBeCloseTo(8712 / 39000, 4);
+    expect(s.returnOnEquity).toBeCloseTo(8712 / 24743, 4);
+    // YoY growth vs FY2023 revenue (33723)
+    expect(s.revenueGrowth).toBeCloseTo((39000 - 33723) / 33723, 4);
+  });
+
+  test('lists only annual (10-K) recent filings', () => {
+    expect(profile.recentFilings.every((f) => f.form === '10-K')).toBe(true);
+    expect(profile.recentFilings[0]).toMatchObject({ accessionNumber: 'A-2024' });
+  });
+
+  test('produces a human-readable narrative', () => {
+    expect(typeof profile.narrative).toBe('string');
+    expect(profile.narrative).toContain('NETFLIX INC');
+    expect(profile.narrative).toMatch(/FY2024/);
+  });
+});

--- a/server/test/ratios.test.js
+++ b/server/test/ratios.test.js
@@ -1,0 +1,47 @@
+const { computeRatios, ratiosForPeriod } = require('../src/ratios');
+const { normalizeCompanyFacts } = require('../src/normalize');
+const { companyfacts } = require('./fixtures/secFixtures');
+
+describe('computeRatios', () => {
+  const periods = normalizeCompanyFacts(companyfacts).periods;
+  const ratios = computeRatios(periods);
+  const byYear = Object.fromEntries(ratios.map((r) => [r.fiscalYear, r]));
+
+  test('one ratio row per period', () => {
+    expect(ratios.length).toBe(periods.length);
+  });
+
+  test('liquidity and return ratios for FY2024', () => {
+    const r = byYear[2024];
+    // currentAssets 9000 / currentLiabilities 10000
+    expect(r.currentRatio).toBeCloseTo(0.9, 5);
+    expect(r.workingCapital).toBe(-1000);
+    expect(r.netMargin).toBeCloseTo(8712 / 39000, 4);
+    expect(r.returnOnEquity).toBeCloseTo(8712 / 24743, 4);
+    expect(r.returnOnAssets).toBeCloseTo(8712 / 53630, 4);
+  });
+
+  test('days ratios are null when AR/AP/inventory are not reported', () => {
+    const r = byYear[2024];
+    expect(r.daysSalesOutstanding).toBeNull();
+    expect(r.daysPayablesOutstanding).toBeNull();
+    expect(r.cashConversionCycle).toBeNull();
+  });
+});
+
+describe('ratiosForPeriod days math', () => {
+  test('DSO / DPO / CCC compute when the inputs exist', () => {
+    const r = ratiosForPeriod({
+      fiscalYear: 2024,
+      revenue: 36500,
+      costOfRevenue: 18250,
+      accountsReceivable: 1000,
+      accountsPayable: 500,
+      inventory: 730,
+    });
+    expect(r.daysSalesOutstanding).toBeCloseTo((1000 / 36500) * 365, 4); // 10
+    expect(r.daysPayablesOutstanding).toBeCloseTo((500 / 18250) * 365, 4); // 10
+    expect(r.daysInventoryOutstanding).toBeCloseTo((730 / 18250) * 365, 4); // 14.6
+    expect(r.cashConversionCycle).toBeCloseTo(10 + 14.6 - 10, 3);
+  });
+});

--- a/server/test/routes.test.js
+++ b/server/test/routes.test.js
@@ -172,6 +172,14 @@ describe('GET /api/sec/segments', () => {
     expect(r.body.diagnostics.axesSeen.length).toBeGreaterThan(0);
     expect(r.body.diagnostics.axisCombinations.some((c) => c.axes.includes('+'))).toBe(true);
   });
+
+  test('years=10 requests more filings (bounded by what the company has filed)', async () => {
+    const app = makeApp();
+    const r = await request(app).get('/api/sec/segments?ticker=NFLX&years=10');
+    expect(r.status).toBe(200);
+    // The fixture only has two 10-Ks, so it parses both; the cap just lifts.
+    expect(r.body.filingsParsed).toBe(2);
+  });
 });
 
 describe('GET /api/sec/all-facts', () => {

--- a/server/test/routes.test.js
+++ b/server/test/routes.test.js
@@ -1,0 +1,98 @@
+const request = require('supertest');
+const { createApp } = require('../src/app');
+const { createSecService, TICKERS_URL } = require('../src/secService');
+const { tickers, submissions, companyfacts } = require('./fixtures/secFixtures');
+
+// Fake SEC client that serves fixtures based on the requested URL.
+function makeApp() {
+  const client = {
+    getJson: jest.fn(async (url) => {
+      if (url === TICKERS_URL) return tickers;
+      if (url.includes('/submissions/')) return submissions;
+      if (url.includes('/companyfacts/')) return companyfacts;
+      const err = new Error(`unexpected url ${url}`);
+      err.status = 404;
+      throw err;
+    }),
+  };
+  const service = createSecService({ client });
+  return createApp({ service });
+}
+
+describe('GET /api/sec/company', () => {
+  test('returns CIK, name, tickers and exchange', async () => {
+    const app = makeApp();
+    const r = await request(app).get('/api/sec/company?ticker=NFLX');
+    expect(r.status).toBe(200);
+    expect(r.body).toMatchObject({
+      ticker: 'NFLX',
+      cik: '0001065280',
+      companyName: 'NETFLIX INC',
+      tickers: ['NFLX'],
+      exchanges: ['NASDAQ'],
+    });
+  });
+
+  test('is case-insensitive on the ticker', async () => {
+    const app = makeApp();
+    const r = await request(app).get('/api/sec/company?ticker=nflx');
+    expect(r.status).toBe(200);
+    expect(r.body.cik).toBe('0001065280');
+  });
+});
+
+describe('GET /api/sec/companyfacts', () => {
+  test('returns wrapped raw companyfacts', async () => {
+    const app = makeApp();
+    const r = await request(app).get('/api/sec/companyfacts?ticker=NFLX');
+    expect(r.status).toBe(200);
+    expect(r.body.cik).toBe('0001065280');
+    expect(r.body.facts.facts['us-gaap'].Revenues).toBeDefined();
+  });
+});
+
+describe('GET /api/sec/model-data', () => {
+  test('returns normalized annual data', async () => {
+    const app = makeApp();
+    const r = await request(app).get('/api/sec/model-data?ticker=NFLX');
+    expect(r.status).toBe(200);
+    expect(r.body.ticker).toBe('NFLX');
+    expect(r.body.periods.map((p) => p.fiscalYear)).toEqual([2024, 2023, 2022]);
+  });
+
+  test('honors the years parameter', async () => {
+    const app = makeApp();
+    const r = await request(app).get('/api/sec/model-data?ticker=NFLX&years=2');
+    expect(r.status).toBe(200);
+    expect(r.body.periods).toHaveLength(2);
+    expect(r.body.periods[0].fiscalYear).toBe(2024);
+  });
+});
+
+describe('error handling', () => {
+  test('400 when ticker is missing', async () => {
+    const app = makeApp();
+    const r = await request(app).get('/api/sec/model-data');
+    expect(r.status).toBe(400);
+    expect(r.body.error).toMatch(/ticker/i);
+  });
+
+  test('400 on a malformed ticker', async () => {
+    const app = makeApp();
+    const r = await request(app).get('/api/sec/company?ticker=not a ticker!');
+    expect(r.status).toBe(400);
+  });
+
+  test('404 for an unknown ticker', async () => {
+    const app = makeApp();
+    const r = await request(app).get('/api/sec/company?ticker=ZZZZ');
+    expect(r.status).toBe(404);
+    expect(r.body.error).toMatch(/no sec cik/i);
+  });
+
+  test('404 for an unknown API route', async () => {
+    const app = makeApp();
+    const r = await request(app).get('/api/sec/nope');
+    expect(r.status).toBe(404);
+  });
+});

--- a/server/test/routes.test.js
+++ b/server/test/routes.test.js
@@ -118,12 +118,26 @@ describe('GET /api/sec/wacc', () => {
     expect(r.body.complete).toBe(true);
   });
 
-  test('still returns (incomplete) when market data is unconfigured', async () => {
+  test('supplies an industry beta even when market data is unconfigured', async () => {
     const app = makeApp();
     const r = await request(app).get('/api/sec/wacc?ticker=NFLX');
     expect(r.status).toBe(200);
     expect(r.body.meta.marketDataConfigured).toBe(false);
-    expect(r.body.missing).toEqual(expect.arrayContaining(['beta', 'marketCap']));
+    // Beta now comes from the Damodaran industry beta, so it is NOT missing.
+    expect(r.body.missing).toContain('marketCap');
+    expect(r.body.missing).not.toContain('beta');
+    expect(r.body.beta.industry).toBe('Entertainment'); // SIC 7841
+    expect(r.body.inputs.beta).toBeGreaterThan(0);
+  });
+});
+
+describe('GET /api/sec/business', () => {
+  test('extracts the Item 1 Business narrative from the latest 10-K', async () => {
+    const app = makeApp();
+    const r = await request(app).get('/api/sec/business?ticker=NFLX');
+    expect(r.status).toBe(200);
+    expect(r.body.sourceDocument).toContain('/Archives/edgar/data/1065280/');
+    expect(r.body.business.excerpt).toMatch(/SampleCo is a synthetic streaming/);
   });
 });
 

--- a/server/test/routes.test.js
+++ b/server/test/routes.test.js
@@ -30,6 +30,7 @@ function makeApp() {
     treasury: {
       getRiskFreeRate: async () => ({ riskFreeRate: 0.043, source: 'default', year: 2026 }),
     },
+    priceData: { getClose: async () => 250, source: 'stub' },
   });
   return createApp({ service });
 }
@@ -118,16 +119,17 @@ describe('GET /api/sec/wacc', () => {
     expect(r.body.complete).toBe(true);
   });
 
-  test('supplies an industry beta even when market data is unconfigured', async () => {
+  test('uses industry beta and a free (price x shares) market cap without a key', async () => {
     const app = makeApp();
     const r = await request(app).get('/api/sec/wacc?ticker=NFLX');
     expect(r.status).toBe(200);
     expect(r.body.meta.marketDataConfigured).toBe(false);
-    // Beta now comes from the Damodaran industry beta, so it is NOT missing.
-    expect(r.body.missing).toContain('marketCap');
+    // Beta from Damodaran industry beta; market cap derived from 250 x 430M shares.
     expect(r.body.missing).not.toContain('beta');
+    expect(r.body.missing).not.toContain('marketCap');
     expect(r.body.beta.industry).toBe('Entertainment'); // SIC 7841
-    expect(r.body.inputs.beta).toBeGreaterThan(0);
+    expect(r.body.beta.deRatioBasis).toMatch(/market/);
+    expect(r.body.inputs.marketValueOfEquity).toBe(250 * 430000000);
   });
 });
 

--- a/server/test/routes.test.js
+++ b/server/test/routes.test.js
@@ -2,6 +2,7 @@ const request = require('supertest');
 const { createApp } = require('../src/app');
 const { createSecService, TICKERS_URL } = require('../src/secService');
 const { tickers, submissions, companyfacts } = require('./fixtures/secFixtures');
+const inlineXbrl = require('./fixtures/inlineXbrl');
 
 // Fake SEC client that serves fixtures based on the requested URL.
 function makeApp() {
@@ -13,6 +14,10 @@ function makeApp() {
       const err = new Error(`unexpected url ${url}`);
       err.status = 404;
       throw err;
+    }),
+    getText: jest.fn(async (url) => {
+      if (url.includes('/Archives/')) return inlineXbrl;
+      throw new Error(`unexpected text url ${url}`);
     }),
   };
   const service = createSecService({
@@ -119,6 +124,20 @@ describe('GET /api/sec/wacc', () => {
     expect(r.status).toBe(200);
     expect(r.body.meta.marketDataConfigured).toBe(false);
     expect(r.body.missing).toEqual(expect.arrayContaining(['beta', 'marketCap']));
+  });
+});
+
+describe('GET /api/sec/segments', () => {
+  test('returns revenue grouped by axis/member from inline XBRL', async () => {
+    const app = makeApp();
+    const r = await request(app).get('/api/sec/segments?ticker=NFLX');
+    expect(r.status).toBe(200);
+    expect(r.body.accessionNumber).toBe('A-2024');
+    expect(r.body.sourceDocument).toContain('/Archives/edgar/data/1065280/');
+    const product = r.body.axes.find((a) => a.axis === 'srt:ProductOrServiceAxis');
+    expect(product).toBeTruthy();
+    const streaming = product.members.find((m) => m.member === 'nflx:StreamingRevenuesMember');
+    expect(streaming.values['2024']).toBe(38000000 * 1000);
   });
 });
 

--- a/server/test/routes.test.js
+++ b/server/test/routes.test.js
@@ -96,6 +96,19 @@ describe('GET /api/sec/profile', () => {
   });
 });
 
+describe('GET /api/sec/balance-sheet', () => {
+  test('returns a Schedule III statement per period', async () => {
+    const app = makeApp();
+    const r = await request(app).get('/api/sec/balance-sheet?ticker=NFLX');
+    expect(r.status).toBe(200);
+    expect(r.body.format).toMatch(/Schedule III/);
+    expect(r.body.statements.length).toBeGreaterThan(0);
+    const s = r.body.statements[0];
+    expect(s.lines.find((l) => l.key === 'asTotal')).toBeTruthy();
+    expect(s.lines.find((l) => l.key === 'elTotal')).toBeTruthy();
+  });
+});
+
 describe('GET /api/sec/ratios', () => {
   test('returns one ratio set per period', async () => {
     const app = makeApp();

--- a/server/test/routes.test.js
+++ b/server/test/routes.test.js
@@ -96,6 +96,17 @@ describe('GET /api/sec/profile', () => {
   });
 });
 
+describe('GET /api/sec/income-statement', () => {
+  test('returns a Schedule III P&L per period', async () => {
+    const app = makeApp();
+    const r = await request(app).get('/api/sec/income-statement?ticker=NFLX');
+    expect(r.status).toBe(200);
+    expect(r.body.format).toMatch(/Schedule III/);
+    expect(r.body.statements.length).toBeGreaterThan(0);
+    expect(r.body.statements[0].lines.find((l) => l.key === 'pfp')).toBeTruthy();
+  });
+});
+
 describe('GET /api/sec/balance-sheet', () => {
   test('returns a Schedule III statement per period', async () => {
     const app = makeApp();

--- a/server/test/routes.test.js
+++ b/server/test/routes.test.js
@@ -69,6 +69,28 @@ describe('GET /api/sec/model-data', () => {
   });
 });
 
+describe('GET /api/sec/all-facts', () => {
+  test('returns every annual concept for the ticker', async () => {
+    const app = makeApp();
+    const r = await request(app).get('/api/sec/all-facts?ticker=NFLX');
+    expect(r.status).toBe(200);
+    expect(r.body.cik).toBe('0001065280');
+    expect(r.body.conceptCount).toBeGreaterThan(0);
+    expect(r.body.concepts.map((c) => c.tag)).toEqual(expect.arrayContaining(['Revenues']));
+  });
+});
+
+describe('GET /api/sec/fields', () => {
+  test('returns curated field metadata without a network call', async () => {
+    const app = makeApp();
+    const r = await request(app).get('/api/sec/fields');
+    expect(r.status).toBe(200);
+    expect(r.body.fields.length).toBeGreaterThanOrEqual(40);
+    const revenue = r.body.fields.find((f) => f.key === 'revenue');
+    expect(revenue).toMatchObject({ statement: 'income', unit: 'USD' });
+  });
+});
+
 describe('error handling', () => {
   test('400 when ticker is missing', async () => {
     const app = makeApp();

--- a/server/test/routes.test.js
+++ b/server/test/routes.test.js
@@ -144,16 +144,20 @@ describe('GET /api/sec/business', () => {
 });
 
 describe('GET /api/sec/segments', () => {
-  test('returns revenue grouped by axis/member from inline XBRL', async () => {
+  test('returns revenue grouped by axis/member, merged across filings, with diagnostics', async () => {
     const app = makeApp();
     const r = await request(app).get('/api/sec/segments?ticker=NFLX');
     expect(r.status).toBe(200);
     expect(r.body.accessionNumber).toBe('A-2024');
     expect(r.body.sourceDocument).toContain('/Archives/edgar/data/1065280/');
+    expect(r.body.filingsParsed).toBe(2); // two 10-Ks in the fixture
     const product = r.body.axes.find((a) => a.axis === 'srt:ProductOrServiceAxis');
     expect(product).toBeTruthy();
     const streaming = product.members.find((m) => m.member === 'nflx:StreamingRevenuesMember');
     expect(streaming.values['2024']).toBe(38000000 * 1000);
+    // diagnostics reveal the multi-axis (product x geography) combination too
+    expect(r.body.diagnostics.axesSeen.length).toBeGreaterThan(0);
+    expect(r.body.diagnostics.axisCombinations.some((c) => c.axes.includes('+'))).toBe(true);
   });
 });
 

--- a/server/test/routes.test.js
+++ b/server/test/routes.test.js
@@ -15,7 +15,17 @@ function makeApp() {
       throw err;
     }),
   };
-  const service = createSecService({ client });
+  const service = createSecService({
+    client,
+    // Deterministic stubs so WACC tests don't depend on env/network.
+    marketData: {
+      configured: false,
+      getOverview: async () => ({ configured: false, beta: null, marketCap: null, source: 'none' }),
+    },
+    treasury: {
+      getRiskFreeRate: async () => ({ riskFreeRate: 0.043, source: 'default', year: 2026 }),
+    },
+  });
   return createApp({ service });
 }
 
@@ -66,6 +76,49 @@ describe('GET /api/sec/model-data', () => {
     expect(r.status).toBe(200);
     expect(r.body.periods).toHaveLength(2);
     expect(r.body.periods[0].fiscalYear).toBe(2024);
+  });
+});
+
+describe('GET /api/sec/profile', () => {
+  test('returns metadata plus a financial snapshot', async () => {
+    const app = makeApp();
+    const r = await request(app).get('/api/sec/profile?ticker=NFLX');
+    expect(r.status).toBe(200);
+    expect(r.body).toMatchObject({ ticker: 'NFLX', cik: '0001065280', name: 'NETFLIX INC' });
+    expect(r.body.snapshot.fiscalYear).toBe(2024);
+    expect(typeof r.body.narrative).toBe('string');
+  });
+});
+
+describe('GET /api/sec/ratios', () => {
+  test('returns one ratio set per period', async () => {
+    const app = makeApp();
+    const r = await request(app).get('/api/sec/ratios?ticker=NFLX');
+    expect(r.status).toBe(200);
+    expect(r.body.ratios.length).toBeGreaterThan(0);
+    expect(r.body.ratios[0]).toHaveProperty('currentRatio');
+  });
+});
+
+describe('GET /api/sec/wacc', () => {
+  test('computes WACC from query-param overrides', async () => {
+    const app = makeApp();
+    const r = await request(app).get(
+      '/api/sec/wacc?ticker=NFLX&beta=1.2&marketCap=90000&costOfDebt=0.05&taxRate=0.2&totalDebt=10000&rf=0.04&erp=0.05'
+    );
+    expect(r.status).toBe(200);
+    expect(r.body.inputs.beta).toBe(1.2);
+    // Re=0.04+1.2*0.05=0.10 ; afterTaxRd=0.05*0.8=0.04 ; 0.9*0.10+0.1*0.04=0.094
+    expect(r.body.wacc).toBeCloseTo(0.094, 5);
+    expect(r.body.complete).toBe(true);
+  });
+
+  test('still returns (incomplete) when market data is unconfigured', async () => {
+    const app = makeApp();
+    const r = await request(app).get('/api/sec/wacc?ticker=NFLX');
+    expect(r.status).toBe(200);
+    expect(r.body.meta.marketDataConfigured).toBe(false);
+    expect(r.body.missing).toEqual(expect.arrayContaining(['beta', 'marketCap']));
   });
 });
 

--- a/server/test/secClient.test.js
+++ b/server/test/secClient.test.js
@@ -1,0 +1,133 @@
+const { createSecClient, createRateLimiter } = require('../src/secClient');
+const { createCache } = require('../src/cache');
+
+// A fetch-like response stub.
+function res(status, body, headers = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: '',
+    headers: { get: (k) => headers[k.toLowerCase()] ?? null },
+    json: async () => body,
+  };
+}
+
+function makeClient(fetchImpl, overrides = {}) {
+  const sleeps = [];
+  // An always-advancing clock so the rate limiter never needs to sleep; this
+  // keeps `sleeps` limited to retry/backoff delays only.
+  let clock = 0;
+  const client = createSecClient({
+    fetchImpl,
+    sleepImpl: (ms) => {
+      sleeps.push(ms);
+      return Promise.resolve();
+    },
+    now: () => {
+      clock += 1e6;
+      return clock;
+    },
+    cache: createCache(60000),
+    maxRetries: 4,
+    baseBackoffMs: 100,
+    maxRequestsPerSecond: 1000,
+    ...overrides,
+  });
+  return { client, sleeps };
+}
+
+describe('createSecClient headers', () => {
+  test('sets SEC-compliant User-Agent and Accept-Encoding', () => {
+    const { client } = makeClient(async () => res(200, {}));
+    expect(client.headers['User-Agent']).toMatch(/@/);
+    expect(client.headers['Accept-Encoding']).toBe('gzip, deflate');
+  });
+});
+
+describe('getJson caching', () => {
+  test('only fetches once for the same URL', async () => {
+    const fetchImpl = jest.fn(async () => res(200, { hello: 'world' }));
+    const { client } = makeClient(fetchImpl);
+    const a = await client.getJson('https://example.com/x.json');
+    const b = await client.getJson('https://example.com/x.json');
+    expect(a).toEqual({ hello: 'world' });
+    expect(b).toEqual({ hello: 'world' });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('getJson retry/backoff', () => {
+  test('retries on 429 then succeeds, honoring Retry-After', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValueOnce(res(429, null, { 'retry-after': '2' }))
+      .mockResolvedValueOnce(res(200, { ok: true }));
+    const { client, sleeps } = makeClient(fetchImpl);
+    const data = await client.getJson('https://example.com/a.json');
+    expect(data).toEqual({ ok: true });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(sleeps).toContain(2000); // Retry-After: 2 seconds
+  });
+
+  test('retries on 5xx then succeeds with exponential backoff', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValueOnce(res(503))
+      .mockResolvedValueOnce(res(500))
+      .mockResolvedValueOnce(res(200, { ok: true }));
+    const { client, sleeps } = makeClient(fetchImpl);
+    const data = await client.getJson('https://example.com/b.json');
+    expect(data).toEqual({ ok: true });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(sleeps).toEqual([100, 200]); // baseBackoff * 2^attempt
+  });
+
+  test('retries on network errors', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('ECONNRESET'))
+      .mockResolvedValueOnce(res(200, { ok: true }));
+    const { client } = makeClient(fetchImpl);
+    await expect(client.getJson('https://example.com/c.json')).resolves.toEqual({ ok: true });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not retry on non-retryable 404', async () => {
+    const fetchImpl = jest.fn(async () => res(404));
+    const { client } = makeClient(fetchImpl);
+    await expect(client.getJson('https://example.com/d.json')).rejects.toMatchObject({
+      status: 404,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  test('gives up after exhausting retries', async () => {
+    const fetchImpl = jest.fn(async () => res(429));
+    const { client } = makeClient(fetchImpl, { maxRetries: 2 });
+    await expect(client.getJson('https://example.com/e.json')).rejects.toMatchObject({
+      status: 429,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+});
+
+describe('createRateLimiter', () => {
+  test('spaces request starts by the minimum interval', async () => {
+    let clock = 0;
+    const sleeps = [];
+    const limiter = createRateLimiter({
+      maxRequestsPerSecond: 10, // 100ms minimum interval
+      now: () => clock,
+      sleepImpl: (ms) => {
+        sleeps.push(ms);
+        clock += ms;
+        return Promise.resolve();
+      },
+    });
+    await limiter(() => Promise.resolve());
+    await limiter(() => Promise.resolve());
+    await limiter(() => Promise.resolve());
+    // First runs immediately; the next two each wait one 100ms interval.
+    expect(sleeps).toEqual([100, 100]);
+  });
+});

--- a/server/test/segments.test.js
+++ b/server/test/segments.test.js
@@ -1,0 +1,73 @@
+const {
+  parseInlineXbrlSegments,
+  groupSegments,
+  extractSegments,
+  humanize,
+} = require('../src/segments');
+const inlineXbrl = require('./fixtures/inlineXbrl');
+
+describe('humanize', () => {
+  test('cleans member/axis QNames', () => {
+    expect(humanize('nflx:StreamingRevenuesMember', 'Member')).toBe('Streaming Revenues');
+    expect(humanize('srt:ProductOrServiceAxis', 'Axis')).toBe('Product Or Service');
+    expect(humanize('country:US')).toBe('US');
+  });
+});
+
+describe('parseInlineXbrlSegments', () => {
+  const facts = parseInlineXbrlSegments(inlineXbrl);
+
+  test('extracts single-axis full-year revenue facts and applies scale', () => {
+    const stream24 = facts.find(
+      (f) => f.axis === 'srt:ProductOrServiceAxis' && f.member === 'nflx:StreamingRevenuesMember' && f.fiscalYear === 2024
+    );
+    expect(stream24.value).toBe(38000000 * 1000); // scale=3
+    expect(stream24.unit).toBe('usd');
+  });
+
+  test('excludes consolidated (no-segment) facts', () => {
+    expect(facts.some((f) => f.value === 39000000 * 1000)).toBe(false);
+  });
+
+  test('excludes partial-year (Q1) facts', () => {
+    expect(facts.some((f) => f.value === 9000000 * 1000)).toBe(false);
+  });
+
+  test('excludes multi-axis intersection cells', () => {
+    expect(facts.some((f) => f.value === 12000000 * 1000)).toBe(false);
+  });
+
+  test('captures both product and geographic axes', () => {
+    const axes = new Set(facts.map((f) => f.axis));
+    expect(axes).toContain('srt:ProductOrServiceAxis');
+    expect(axes).toContain('srt:StatementGeographicalAxis');
+  });
+
+  test('returns [] for junk input', () => {
+    expect(parseInlineXbrlSegments('')).toEqual([]);
+    expect(parseInlineXbrlSegments(null)).toEqual([]);
+  });
+});
+
+describe('groupSegments', () => {
+  const grouped = groupSegments(parseInlineXbrlSegments(inlineXbrl));
+
+  test('groups by axis and member with per-year values', () => {
+    expect(grouped.fiscalYears).toEqual([2024, 2023]);
+    const product = grouped.axes.find((a) => a.axis === 'srt:ProductOrServiceAxis');
+    expect(product.label).toBe('Product Or Service');
+    const streaming = product.members.find((m) => m.member === 'nflx:StreamingRevenuesMember');
+    expect(streaming.label).toBe('Streaming Revenues');
+    expect(streaming.values[2024]).toBe(38000000 * 1000);
+    expect(streaming.values[2023]).toBe(33000000 * 1000);
+  });
+
+  test('members are sorted by latest-year value descending', () => {
+    const product = grouped.axes.find((a) => a.axis === 'srt:ProductOrServiceAxis');
+    expect(product.members[0].member).toBe('nflx:StreamingRevenuesMember'); // 38B > 1B
+  });
+
+  test('extractSegments is parse + group', () => {
+    expect(extractSegments(inlineXbrl)).toEqual(grouped);
+  });
+});

--- a/server/test/segments.test.js
+++ b/server/test/segments.test.js
@@ -1,6 +1,8 @@
 const {
   parseInlineXbrlSegments,
+  parseRevenueFacts,
   groupSegments,
+  deriveCombinedAxes,
   extractSegments,
   humanize,
 } = require('../src/segments');
@@ -69,5 +71,25 @@ describe('groupSegments', () => {
 
   test('extractSegments is parse + group', () => {
     expect(extractSegments(inlineXbrl)).toEqual(grouped);
+  });
+});
+
+describe('deriveCombinedAxes', () => {
+  // The fixture has one multi-axis cell: Streaming x US = 12,000,000 (scale 3).
+  const derived = deriveCombinedAxes(parseRevenueFacts(inlineXbrl));
+
+  test('surfaces a summed breakdown for each axis in a multi-axis cell', () => {
+    const geo = derived.find((a) => a.axis === 'srt:StatementGeographicalAxis');
+    expect(geo).toBeTruthy();
+    expect(geo.derived).toBe(true);
+    expect(geo.label).toMatch(/summed across other dimensions/);
+    const us = geo.members.find((m) => m.member === 'country:US');
+    expect(us.values[2024]).toBe(12000000 * 1000);
+  });
+
+  test('ignores single-axis facts (only sums multi-axis cells)', () => {
+    // Single-axis US revenue (15,000,000) must NOT inflate the derived figure.
+    const geo = derived.find((a) => a.axis === 'srt:StatementGeographicalAxis');
+    expect(geo.members.find((m) => m.member === 'country:US').values[2024]).toBe(12000000 * 1000);
   });
 });

--- a/server/test/tagMap.test.js
+++ b/server/test/tagMap.test.js
@@ -1,0 +1,47 @@
+const TAG_MAP = require('../src/tagMap');
+
+describe('tagMap', () => {
+  test('revenue has primary tag and fallback', () => {
+    expect(TAG_MAP.revenue.tags).toEqual([
+      'Revenues',
+      'RevenueFromContractWithCustomerExcludingAssessedTax',
+    ]);
+  });
+
+  test('costOfRevenue falls back to CostOfGoodsAndServicesSold', () => {
+    expect(TAG_MAP.costOfRevenue.tags).toContain('CostOfGoodsAndServicesSold');
+  });
+
+  test('EPS and shares use non-USD units', () => {
+    expect(TAG_MAP.dilutedEPS.unit).toBe('USD/shares');
+    expect(TAG_MAP.dilutedShares.unit).toBe('shares');
+  });
+
+  test('all required modelling fields are mapped', () => {
+    const expected = [
+      'revenue',
+      'costOfRevenue',
+      'grossProfit',
+      'operatingIncome',
+      'netIncome',
+      'totalAssets',
+      'currentAssets',
+      'cashAndEquivalents',
+      'totalLiabilities',
+      'stockholdersEquity',
+      'operatingCashFlow',
+      'capitalExpenditure',
+      'dilutedEPS',
+      'dilutedShares',
+    ];
+    expect(Object.keys(TAG_MAP)).toEqual(expected);
+  });
+
+  test('every field has at least one tag and a unit', () => {
+    for (const [field, def] of Object.entries(TAG_MAP)) {
+      expect(Array.isArray(def.tags)).toBe(true);
+      expect(def.tags.length).toBeGreaterThan(0);
+      expect(typeof def.unit).toBe('string');
+    }
+  });
+});

--- a/server/test/tagMap.test.js
+++ b/server/test/tagMap.test.js
@@ -2,7 +2,7 @@ const TAG_MAP = require('../src/tagMap');
 
 describe('tagMap', () => {
   test('revenue has primary tag and fallback', () => {
-    expect(TAG_MAP.revenue.tags).toEqual([
+    expect(TAG_MAP.revenue.tags.slice(0, 2)).toEqual([
       'Revenues',
       'RevenueFromContractWithCustomerExcludingAssessedTax',
     ]);
@@ -17,8 +17,8 @@ describe('tagMap', () => {
     expect(TAG_MAP.dilutedShares.unit).toBe('shares');
   });
 
-  test('all required modelling fields are mapped', () => {
-    const expected = [
+  test('all original headline fields remain mapped', () => {
+    const required = [
       'revenue',
       'costOfRevenue',
       'grossProfit',
@@ -34,14 +34,22 @@ describe('tagMap', () => {
       'dilutedEPS',
       'dilutedShares',
     ];
-    expect(Object.keys(TAG_MAP)).toEqual(expected);
+    expect(Object.keys(TAG_MAP)).toEqual(expect.arrayContaining(required));
   });
 
-  test('every field has at least one tag and a unit', () => {
-    for (const [field, def] of Object.entries(TAG_MAP)) {
+  test('expanded into a full three-statement model', () => {
+    expect(Object.keys(TAG_MAP).length).toBeGreaterThanOrEqual(40);
+    const statements = new Set(Object.values(TAG_MAP).map((d) => d.statement));
+    expect(statements).toEqual(new Set(['income', 'pershare', 'balance', 'cashflow']));
+  });
+
+  test('every field has tags, a unit, a label and a statement', () => {
+    for (const def of Object.values(TAG_MAP)) {
       expect(Array.isArray(def.tags)).toBe(true);
       expect(def.tags.length).toBeGreaterThan(0);
       expect(typeof def.unit).toBe('string');
+      expect(typeof def.label).toBe('string');
+      expect(['income', 'pershare', 'balance', 'cashflow']).toContain(def.statement);
     }
   });
 });

--- a/server/test/wacc.test.js
+++ b/server/test/wacc.test.js
@@ -60,7 +60,23 @@ describe('computeWacc', () => {
     });
     expect(r.wacc).toBeNull();
     expect(r.complete).toBe(false);
-    expect(r.missing).toEqual(expect.arrayContaining(['beta', 'marketCap', 'costOfDebt']));
+    expect(r.missing).toEqual(expect.arrayContaining(['beta', 'equity', 'costOfDebt']));
+  });
+
+  test('falls back to book equity for the weight when market cap is absent', () => {
+    const r = computeWacc({
+      period: basePeriod, // totalDebt 10000
+      beta: 1.2,
+      bookEquity: 30000, // no marketCap
+      riskFreeRate: 0.04,
+      equityRiskPremium: 0.05,
+    });
+    expect(r.inputs.equityBasis).toBe('book');
+    expect(r.inputs.marketValueOfEquity).toBeNull();
+    expect(r.inputs.equityUsed).toBe(30000);
+    // E/V = 30000/40000 = 0.75, D/V = 0.25
+    expect(r.components.weightEquity).toBeCloseTo(0.75, 6);
+    expect(r.wacc).not.toBeNull();
   });
 });
 

--- a/server/test/wacc.test.js
+++ b/server/test/wacc.test.js
@@ -1,0 +1,104 @@
+const { computeWacc, effectiveTaxRate } = require('../src/wacc');
+const { parseLatest10Year } = require('../src/treasury');
+const { createMarketDataProvider } = require('../src/marketData');
+
+const basePeriod = {
+  fiscalYear: 2024,
+  shortTermDebt: 1000,
+  longTermDebt: 9000,
+  interestExpense: 500,
+  incomeTaxExpense: 200,
+  pretaxIncome: 1000,
+};
+
+describe('effectiveTaxRate', () => {
+  test('computes and clamps to 0–50%', () => {
+    expect(effectiveTaxRate({ incomeTaxExpense: 200, pretaxIncome: 1000 })).toBeCloseTo(0.2, 5);
+    expect(effectiveTaxRate({ incomeTaxExpense: 600, pretaxIncome: 1000 })).toBe(0.5);
+    expect(effectiveTaxRate({ incomeTaxExpense: 200, pretaxIncome: 0 })).toBeNull();
+  });
+});
+
+describe('computeWacc', () => {
+  test('full computation', () => {
+    const r = computeWacc({
+      period: basePeriod,
+      beta: 1.2,
+      marketCap: 90000,
+      riskFreeRate: 0.04,
+      equityRiskPremium: 0.05,
+    });
+    // Re = 0.04 + 1.2*0.05 = 0.10 ; after-tax Rd = 0.05*(1-0.2)=0.04
+    // E/V=0.9, D/V=0.1 -> 0.9*0.10 + 0.1*0.04 = 0.094
+    expect(r.components.costOfEquity).toBeCloseTo(0.1, 6);
+    expect(r.components.afterTaxCostOfDebt).toBeCloseTo(0.04, 6);
+    expect(r.components.weightEquity).toBeCloseTo(0.9, 6);
+    expect(r.wacc).toBeCloseTo(0.094, 6);
+    expect(r.complete).toBe(true);
+    expect(r.missing).toEqual([]);
+  });
+
+  test('overrides take precedence over fetched inputs', () => {
+    const r = computeWacc({
+      period: basePeriod,
+      beta: 1.2,
+      marketCap: 90000,
+      riskFreeRate: 0.04,
+      equityRiskPremium: 0.05,
+      overrides: { beta: 2.0 },
+    });
+    // Re = 0.04 + 2*0.05 = 0.14 -> 0.9*0.14 + 0.1*0.04 = 0.13
+    expect(r.inputs.beta).toBe(2.0);
+    expect(r.wacc).toBeCloseTo(0.13, 6);
+  });
+
+  test('reports missing inputs and returns null wacc when incomplete', () => {
+    const r = computeWacc({
+      period: { fiscalYear: 2024 },
+      riskFreeRate: 0.04,
+      equityRiskPremium: 0.05,
+    });
+    expect(r.wacc).toBeNull();
+    expect(r.complete).toBe(false);
+    expect(r.missing).toEqual(expect.arrayContaining(['beta', 'marketCap', 'costOfDebt']));
+  });
+});
+
+describe('treasury parseLatest10Year', () => {
+  test('extracts the most recent 10-year rate as a decimal', () => {
+    const xml =
+      '<feed><entry><content><m:properties>' +
+      '<d:BC_10YEAR>4.10</d:BC_10YEAR></m:properties></content></entry>' +
+      '<entry><content><m:properties>' +
+      '<d:BC_10YEAR>4.32</d:BC_10YEAR></m:properties></content></entry></feed>';
+    expect(parseLatest10Year(xml)).toBeCloseTo(0.0432, 6);
+  });
+
+  test('returns null when no rate is present', () => {
+    expect(parseLatest10Year('<feed></feed>')).toBeNull();
+  });
+});
+
+describe('marketData provider (Alpha Vantage)', () => {
+  test('parses Beta and MarketCapitalization from OVERVIEW', async () => {
+    const client = {
+      getJson: async () => ({ Name: 'Netflix Inc', Beta: '1.28', MarketCapitalization: '350000000000' }),
+    };
+    const provider = createMarketDataProvider({ client, apiKey: 'TESTKEY' });
+    const o = await provider.getOverview('NFLX');
+    expect(o).toMatchObject({ configured: true, beta: 1.28, marketCap: 350000000000 });
+  });
+
+  test('is a no-op when no API key is configured', async () => {
+    const provider = createMarketDataProvider({ client: {}, apiKey: '' });
+    expect(provider.configured).toBe(false);
+    const o = await provider.getOverview('NFLX');
+    expect(o).toMatchObject({ configured: false, beta: null, marketCap: null });
+  });
+
+  test('throws on a throttling Note', async () => {
+    const client = { getJson: async () => ({ Note: 'rate limit' }) };
+    const provider = createMarketDataProvider({ client, apiKey: 'TESTKEY' });
+    await expect(provider.getOverview('NFLX')).rejects.toThrow(/Market-data provider/);
+  });
+});


### PR DESCRIPTION
## Summary

This repo is the static Jekyll/reveal.js slideshow (no backend), so this adds a self-contained **Node.js + Express** service under `server/` that fetches structured annual **10-K** financials from the official **SEC EDGAR XBRL JSON APIs** — no API key, no paid plan, no PDF scraping. It runs independently of the GitHub Pages site.

### What's included
- **SEC HTTP client** (`secClient.js`): SEC-compliant `User-Agent` (env-driven contact email) + `Accept-Encoding` headers, ≤10 req/s rate limiter, retry/backoff on 429/5xx (honors `Retry-After`), and a 24h in-memory cache.
- **Ticker → CIK** (`cikLookup.js`): resolution + 10-digit padding (`1065280` → `CIK0001065280`).
- **Tag mapping** (`tagMap.js`): all 14 modelling fields → US-GAAP tags with fallback order.
- **Normalizer** (`normalize.js`): filters `form="10-K"` + `fp="FY"` (drops 10-Q/partial periods), prefers USD, derives total liabilities from current + non-current when `Liabilities` is missing, prefers original filings over restated comparatives, and emits a `rawTagsUsed` audit trail (tag, unit, fiscal year, accession #, filed date, form) per value.
- **REST routes**: `GET /api/sec/company`, `/companyfacts`, `/model-data?ticker=&years=`, `/concept`.
- **Frontend** (`public/index.html`): ticker input, fetch button, loading/error states, financials table with raw-tag tooltips and a raw-JSON drawer.
- **Docs**: new README section (endpoints, no-key/User-Agent env var, rate limits, XBRL-vs-PDF rationale, auditability caveats).

### Configuration
Contact email defaults via `SEC_CONTACT_EMAIL` (see `server/.env.example`); all rate-limit/cache/backoff knobs are env-overridable.

## Test plan
- [x] `npm test` — 49 Jest tests pass (mocked SEC responses): CIK conversion/padding, 10-K/FY filtering, latest-period selection, fallback tags, missing-data handling, caching, retry/backoff.
- [x] Server boots; `/api/sec/health`, static frontend, and 400/404 error paths verified locally.
- [ ] **Live SEC test pending** — the build container blocks outbound HTTPS, so run on a machine with network: `cd server && npm install && cp .env.example .env && npm start`, then open `http://localhost:3000` and fetch `NFLX` (or `curl "http://localhost:3000/api/sec/model-data?ticker=NFLX&years=5"`).

https://claude.ai/code/session_01FbHVbxCenmVmwA3p5UoavL

---
_Generated by [Claude Code](https://claude.ai/code/session_01FbHVbxCenmVmwA3p5UoavL)_